### PR TITLE
fix: properly cap oskills at 3

### DIFF
--- a/api/src/utils/skill-calculator.test.ts
+++ b/api/src/utils/skill-calculator.test.ts
@@ -117,10 +117,13 @@ describe("D2SkillParser", () => {
     it("should apply multiple direct skill bonuses", () => {
       const char = createMockCharacter(
         "Sorceress",
-        [{ name: "Fire Ball", level: 20 }],
         [
-          { name: "Item1", properties: ["+3 to Fire Ball"] },
-          { name: "Item2", properties: ["+2 to Fire Ball"] },
+          { name: "Fire Ball", level: 20 },
+          { name: "Blessed Hammer", level: 1 },
+        ],
+        [
+          { name: "Item1", properties: ["+3 to Blessed Hammer"] },
+          { name: "Item2", properties: ["+2 to Blessed Hammer"] },
         ]
       );
 
@@ -129,9 +132,9 @@ describe("D2SkillParser", () => {
       expect(result).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            skill: "Fire Ball",
-            level: 25,
-            baseLevel: 20,
+            skill: "Blessed Hammer",
+            level: 6,
+            baseLevel: 1,
           }),
         ])
       );
@@ -666,6 +669,87 @@ describe("D2SkillParser", () => {
           invalidChar as unknown as CharacterResponse
         );
       }).toThrow("Invalid character data");
+    });
+  });
+
+describe("Oskill Capping", () => {
+    it("should cap native class direct skill bonus at +3 when from item", () => {
+      const char = createMockCharacter(
+        "Sorceress",
+        [{ name: "Fire Ball", level: 20 }],
+        [{ name: "Item", properties: ["+30 to Fire Ball"] }]
+      );
+
+      const result = parser.calculateTotalSkills(char);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            skill: "Fire Ball",
+            level: 23,
+            baseLevel: 20,
+          }),
+        ])
+      );
+    });
+
+    it("should not cap class-specific direct skill bonus", () => {
+      const char = createMockCharacter(
+        "Sorceress",
+        [{ name: "Fire Ball", level: 20 }],
+        [{ name: "Item", properties: ["+30 to Fire Ball (Sorceress Only)"] }]
+      );
+
+      const result = parser.calculateTotalSkills(char);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            skill: "Fire Ball",
+            level: 50,
+            baseLevel: 20,
+          }),
+        ])
+      );
+    });
+
+    it("should not cap non-native skill bonuses", () => {
+      const char = createMockCharacter(
+        "Necromancer",
+        [
+          { name: "Raise Skeleton", level: 20 },
+          { name: "Fire Ball", level: 1 },
+        ],
+        [{ name: "Item", properties: ["+30 to Fire Ball"] }]
+      );
+
+      const result = parser.calculateTotalSkills(char);
+
+      const fireBall = result.find((s) => s.skill === "Fire Ball");
+      expect(fireBall?.level).toBe(31);
+    });
+
+    it("should cap total oskill bonus at +3 per character, not per item", () => {
+      const char = createMockCharacter(
+        "Sorceress",
+        [{ name: "Fire Ball", level: 20 }],
+        [
+          { name: "Item1", properties: ["+3 to Fire Ball"] },
+          { name: "Item2", properties: ["+3 to Fire Ball"] },
+        ]
+      );
+
+      const result = parser.calculateTotalSkills(char);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            skill: "Fire Ball",
+            level: 23,
+            baseLevel: 20,
+          }),
+        ])
+      );
     });
   });
 });

--- a/api/src/utils/skill-calculator.ts
+++ b/api/src/utils/skill-calculator.ts
@@ -1191,6 +1191,7 @@ class D2SkillParser {
     }
 
     const bonuses: SkillBonus[] = [];
+    const oskillBonuses = new Map<string, number>();
     const totalSkills = new Map<string, number>();
     const baseLevels = new Map<string, number>();
     const character = characterData.character;
@@ -1224,10 +1225,13 @@ class D2SkillParser {
 
     // Apply bonuses in correct order: direct -> tree -> class -> all
     this.log("Applying bonuses in order:");
-    this.applyBonusesByType(bonuses, "direct", characterClass, totalSkills);
+    this.applyBonusesByType(bonuses, "direct", characterClass, totalSkills, oskillBonuses);
     this.applyBonusesByType(bonuses, "tree", characterClass, totalSkills);
     this.applyBonusesByType(bonuses, "class", characterClass, totalSkills);
     this.applyBonusesByType(bonuses, "all", characterClass, totalSkills);
+
+    // Apply oskill bonuses with per-character cap
+    this.applyOskillBonuses(oskillBonuses, totalSkills);
 
     const baseSkills = new Set(character.skills.map((skill) => skill.name));
     for (const [skillName] of totalSkills.entries()) {
@@ -1246,6 +1250,31 @@ class D2SkillParser {
         baseLevel: baseLevels.get(skill),
       }));
     return sortedSkills;
+  }
+
+private isNativeToClass(skillName: string, characterClass: string): boolean {
+    const skill = this.skillDefinitions.find(
+      (s) => this.normalize(s.name) === this.normalize(skillName)
+    );
+    if (!skill) return false;
+    return skill.categories.some(
+      (cat) => this.normalize(cat) === `${characterClass} skills`
+    );
+  }
+
+  private applyOskillBonuses(
+    oskillBonuses: Map<string, number>,
+    totalSkills: Map<string, number>
+  ) {
+    oskillBonuses.forEach((amount, skillName) => {
+      const cappedAmount = Math.min(amount, 3);
+      const currentLevel = totalSkills.get(skillName) || 0;
+      const newLevel = currentLevel + cappedAmount;
+      totalSkills.set(skillName, newLevel);
+      this.log(
+        `Applied oskill bonus to ${skillName}: +${cappedAmount} (${currentLevel} -> ${newLevel})${cappedAmount !== amount ? ` [capped from +${amount}]` : ""}`
+      );
+    });
   }
 
   private parseProperty(prop: string, characterClass: string): SkillBonus[] {
@@ -1349,14 +1378,15 @@ class D2SkillParser {
     bonuses: SkillBonus[],
     type: SkillBonus["type"],
     characterClass: string,
-    totalSkills: Map<string, number>
+    totalSkills: Map<string, number>,
+    oskillBonuses?: Map<string, number>
   ) {
     bonuses
       .filter((bonus) => bonus.type === type)
       .forEach((bonus) => {
         switch (type) {
           case "direct":
-            this.applyDirectBonus(bonus, totalSkills);
+            this.applyDirectBonus(bonus, totalSkills, characterClass, oskillBonuses);
             break;
           case "tree":
             this.applyTreeBonus(bonus, characterClass, totalSkills);
@@ -1373,19 +1403,31 @@ class D2SkillParser {
 
   private applyDirectBonus(
     bonus: SkillBonus,
-    totalSkills: Map<string, number>
+    totalSkills: Map<string, number>,
+    characterClass: string,
+    oskillBonuses?: Map<string, number>
   ) {
     const skill = this.skillDefinitions.find(
       (s) => this.normalize(s.name) === this.normalize(bonus.target)
     );
 
     if (skill) {
-      const currentLevel = totalSkills.get(skill.name) || 0;
-      const newLevel = currentLevel + bonus.amount;
-      totalSkills.set(skill.name, newLevel);
-      this.log(
-        `Applied direct bonus to ${skill.name}: +${bonus.amount} (${currentLevel} -> ${newLevel})`
-      );
+      const isNative = this.isNativeToClass(skill.name, characterClass);
+      const isClassSpecific = bonus.source.toLowerCase().includes(" only");
+      if (isNative && oskillBonuses && !isClassSpecific) {
+        const currentOskill = oskillBonuses.get(skill.name) || 0;
+        oskillBonuses.set(skill.name, currentOskill + bonus.amount);
+        this.log(
+          `Accumulated oskill bonus for ${skill.name}: +${bonus.amount} (total: ${currentOskill + bonus.amount})`
+        );
+      } else {
+        const currentLevel = totalSkills.get(skill.name) || 0;
+        const newLevel = currentLevel + bonus.amount;
+        totalSkills.set(skill.name, newLevel);
+        this.log(
+          `Applied direct bonus to ${skill.name}: +${bonus.amount} (${currentLevel} -> ${newLevel})`
+        );
+      }
     }
   }
 


### PR DESCRIPTION
Oskills are capped at +3 for specific skills when on that class (see https://wiki.projectdiablo2.com/wiki/Skill_Changes#OSkills), but they were not being capped at 3 in profiles causing items like Corpsemourn to show people's CE at over level 70 skill level (e.g. https://pd2.tools/builds/character/FM-KainZaps?nav=vhbzc53r&items=Corpsemourn&skills=%5B%7B%22name%22%3A%22Corpse+Explosion%22%2C%22minLevel%22%3A20%7D%5D&query=corpse).

I tried to come up with tests for the various edge cases, but let me know if any of them don't seem quite correct.