### PR TITLE
fix: add fire tag to corpse explosion

### DIFF
--- a/api/src/utils/skill-calculator.ts
+++ b/api/src/utils/skill-calculator.ts
@@ -722,6 +722,7 @@ class D2SkillParser {
         "poison and bone skills",
         "necromancer skills",
         "corpse explosion",
+        "fire skills",
       ],
     },
     {


### PR DESCRIPTION
This was missing causing it to not count items like Magefist