### PR TITLE
fix: blood warp is a necro summoning skill not a curse skill

### DIFF
--- a/api/src/utils/skill-calculator.ts
+++ b/api/src/utils/skill-calculator.ts
@@ -848,7 +848,7 @@ class D2SkillParser {
     // New Necromancer Skills
     {
       name: "Blood Warp",
-      categories: ["curses skills", "necromancer skills", "blood warp"],
+      categories: ["summoning skills", "necromancer skills", "blood warp"],
     },
     {
       name: "Dark Pact",


### PR DESCRIPTION
The blood warp level is currently not displayed correctly