### PR TITLE
Add Critical/Deadly Strike and Smite damage modeling

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -44,6 +44,10 @@ jobs:
         working-directory: ./web
         run: npm run lint
 
+      - name: Run tests
+        working-directory: ./web
+        run: npm test
+
       - name: Build
         working-directory: ./web
         run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-s
 **Project Summary:**
 This repository powers pd2.tools, a Project Diablo 2 toolkit with a React/Vite/Mantine frontend and a TypeScript Express API backed by Postgres and Redis; it ingests PD2 character data through scheduled jobs, stores season-aware characters, accounts, items, mercenaries, snapshots, economy listings, online-player history, and leaderboards, then exposes UI flows for build discovery, character/account inspection, economy price tracking, statistics, leaderboards, corrupted-zone tracking, character export, and damage/stat calculations using committed PD2 game data tables, with Docker Compose and GitHub Actions covering local/dev/prod deployment, linting, type checks, builds, and backend tests.
 
+**Project Wiki:** https://github.com/coleestrin/pd2-tools/wiki
+
 **One very important principle to follow at all times is always try to solve the problem with the bare minimum number of changes. Always be very thorough in your research and analysis of the codebase, be certain that your answer is correct always. Don't make assumptions, instead put in the effort to verify things and actually read the code and trace logic.**
 
 ## 1. Think Before Coding

--- a/api/src/routes/characters.ts
+++ b/api/src/routes/characters.ts
@@ -42,7 +42,24 @@ function attachDamageCalculation(
 
   try {
     enrichArmoryPayload(data);
-    data.damageCalculation = calculateDamage(data);
+    const damageCalculation = calculateDamage(data);
+    data.damageCalculation = damageCalculation;
+
+    const defaultWeaponId =
+      damageCalculation.defaultSelection?.weaponId ||
+      damageCalculation.weaponOptions[0]?.id;
+    const defaultAttack = damageCalculation.profiles.find(
+      (profile) =>
+        profile.weaponId === defaultWeaponId &&
+        profile.skillId === "Basic Attack" &&
+        profile.playerAuraId === "none" &&
+        profile.transformationId === "none"
+    );
+    const criticalStrike =
+      defaultAttack?.strikeBreakdowns[0]?.rawCriticalChance;
+    if (data.realStats && criticalStrike !== undefined) {
+      data.realStats.criticalStrike = criticalStrike;
+    }
   } catch (error: unknown) {
     logger.warn("Damage calculation failed", {
       character: data.character?.name,

--- a/api/src/routes/routes.test.ts
+++ b/api/src/routes/routes.test.ts
@@ -307,6 +307,63 @@ describe("API Routes", () => {
         );
       });
 
+      it("should expose the equipped weapon's passive Critical Strike chance", async () => {
+        const mockCharacter = {
+          character: {
+            name: "TestAmazon",
+            level: 90,
+            class: { id: 0, name: "Amazon" },
+            attributes: {
+              strength: 100,
+              dexterity: 100,
+              vitality: 100,
+              energy: 100,
+            },
+            skills: [{ id: 9, name: "Critical Strike", level: 3 }],
+          },
+          items: [],
+          realSkills: [
+            { skill: "Critical Strike", level: 15, baseLevel: 3 },
+          ],
+          realStats: { criticalStrike: 0 },
+        };
+
+        (characterDB.getCharacterByName as jest.Mock).mockResolvedValue(
+          mockCharacter
+        );
+        (calculateDamage as jest.Mock).mockReturnValueOnce({
+          weaponOptions: [{ id: "primary:right:missile" }],
+          skillOptions: [],
+          playerAuraOptions: [],
+          transformationOptions: [],
+          alwaysActiveAuras: [],
+          defaultSelection: {
+            weaponId: "primary:right:missile",
+            skillId: "Strafe",
+            playerAuraId: "none",
+            playerAuraCarrier: "self",
+            playerAuraLevel: 0,
+            transformationId: "none",
+          },
+          profiles: [
+            {
+              weaponId: "primary:right:missile",
+              skillId: "Basic Attack",
+              playerAuraId: "none",
+              transformationId: "none",
+              strikeBreakdowns: [{ rawCriticalChance: 59 }],
+            },
+          ],
+          notes: [],
+        });
+
+        const response = await request(app)
+          .get("/api/v1/characters/TestAmazon")
+          .expect(200);
+
+        expect(response.body.realStats.criticalStrike).toBe(59);
+      });
+
       it("should handle different game modes", async () => {
         (characterDB.getCharacterByName as jest.Mock).mockResolvedValue({});
 

--- a/api/src/types/damage.ts
+++ b/api/src/types/damage.ts
@@ -6,6 +6,8 @@ export type DamageElement =
   | "magic"
   | "poison";
 
+export type DamageType = DamageElement | "critical" | "deadly";
+
 export interface DamageRange {
   min: number;
   max: number;
@@ -42,11 +44,34 @@ export interface DamageSourceReference {
   note?: string;
 }
 
+export interface DamageStrikeModifiers {
+  criticalChance: number;
+  deadlyStrikeChance: number;
+  maxDeadlyStrikeChance: number;
+  criticalMultiplierBonus: number;
+  deadlyStrikeMultiplierBonus: number;
+}
+
+export interface DamageStrikeBreakdown {
+  id: string;
+  label: string;
+  physicalComponentIds: string[];
+  rawCriticalChance: number;
+  criticalChance: number;
+  criticalMultiplier: number;
+  rawDeadlyStrikeChance: number;
+  rawMaxDeadlyStrikeChance: number;
+  deadlyStrikeChance: number;
+  maxDeadlyStrikeChance: number;
+  effectiveDeadlyStrikeChance: number;
+  deadlyStrikeMultiplier: number;
+}
+
 export interface DamageComponent {
   id: string;
   label: string;
   source: DamageComponentSource;
-  damageType: DamageElement;
+  damageType: DamageType;
   timing: DamageComponentTiming;
   damage: DamageRange;
   baseDamage?: DamageRange;
@@ -62,7 +87,7 @@ export interface DamageTotals {
   combinedDamage: DamageRange;
   averageInstantDamage: number;
   averageCombinedDamage: number;
-  byElement: Partial<Record<DamageElement, DamageRange>>;
+  byElement: Partial<Record<DamageType, DamageRange>>;
   poisonDamage?: PoisonDamage;
 }
 
@@ -76,6 +101,7 @@ export interface DamageWeaponOption {
     | "two_handed"
     | "missile"
     | "kick"
+    | "smite"
     | "summon"
     | "unarmed"
     | "dual_wield"
@@ -122,6 +148,7 @@ export interface DamageAuraLevelBonus {
     Record<Exclude<DamageElement, "physical" | "poison">, DamageRange>
   >;
   poisonDamage?: PoisonDamagePayload;
+  strikeModifiers: DamageStrikeModifiers;
 }
 
 export interface DamageTransformationOption {
@@ -213,6 +240,7 @@ export interface DamageProfile {
   activeAuras: ActiveAuraSummary[];
   damageScope: DamageProfileScope;
   damageComponents: DamageComponent[];
+  strikeBreakdowns: DamageStrikeBreakdown[];
   damageTotals: DamageTotals;
   auraPulseDamageComponents?: DamageComponent[];
   auraPulseDamageTotals?: DamageTotals;

--- a/api/src/types/item.ts
+++ b/api/src/types/item.ts
@@ -25,6 +25,7 @@ export interface IItemDamage {
   two_handed: IHandDamage;
   missile: IHandDamage;
   kick?: IHandDamage;
+  smite?: IHandDamage;
 }
 
 export interface IStatBonus {

--- a/api/src/types/stats.ts
+++ b/api/src/types/stats.ts
@@ -23,6 +23,7 @@ export interface CharStats {
 
   //Damage Procs
   crushingBlow: number;
+  criticalStrike: number;
   deadlyStrike: number;
   openWounds: number;
   openWoundsDPS: number;

--- a/api/src/utils/armory-payload.ts
+++ b/api/src/utils/armory-payload.ts
@@ -11,7 +11,7 @@ type ArmorTable = {
   rowsByCode: Map<string, string[]>;
 };
 
-type ArmorBootData = {
+type ArmorAttackData = {
   damage: { minimum: number; maximum: number };
   statBonus?: { strength?: number; dexterity?: number };
 };
@@ -127,7 +127,24 @@ function isEquippedBootItem(item: IItem): boolean {
   return typeCode === "boot" || typeName.includes("boot");
 }
 
-function getArmorBootData(item: IItem): ArmorBootData | undefined {
+function isEquippedShieldItem(item: IItem): boolean {
+  if (
+    item.location?.zone !== "Equipped" ||
+    !item.location?.equipment?.includes("Left Hand")
+  ) {
+    return false;
+  }
+
+  const typeCode = item.base?.type_code?.toLowerCase();
+  const typeName = item.base?.type?.toLowerCase() || "";
+  return (
+    typeCode === "shie" ||
+    typeCode === "ashd" ||
+    typeName.includes("shield")
+  );
+}
+
+function getArmorAttackData(item: IItem): ArmorAttackData | undefined {
   const tableRow = getArmorRowForItem(item);
   if (!tableRow) {
     return undefined;
@@ -160,7 +177,7 @@ function enrichBootItem(item: IItem): void {
     return;
   }
 
-  const bootData = getArmorBootData(item);
+  const bootData = getArmorAttackData(item);
   if (!bootData) {
     return;
   }
@@ -186,11 +203,45 @@ function enrichBootItem(item: IItem): void {
   }
 }
 
+function enrichShieldItem(item: IItem): void {
+  if (!isEquippedShieldItem(item)) {
+    return;
+  }
+
+  const shieldData = getArmorAttackData(item);
+  if (!shieldData) {
+    return;
+  }
+
+  item.base.damage = {
+    one_handed: item.base.damage?.one_handed || {},
+    two_handed: item.base.damage?.two_handed || {},
+    missile: item.base.damage?.missile || {},
+    smite: shieldData.damage,
+  };
+  item.damage = {
+    one_handed: item.damage?.one_handed || {},
+    two_handed: item.damage?.two_handed || {},
+    missile: item.damage?.missile || {},
+    smite: shieldData.damage,
+  };
+
+  if (shieldData.statBonus) {
+    item.base.stat_bonus = {
+      ...item.base.stat_bonus,
+      ...shieldData.statBonus,
+    };
+  }
+}
+
 export function enrichArmoryPayload<T extends ArmoryPayload>(payload: T): T {
   if (!Array.isArray(payload.items)) {
     return payload;
   }
 
-  payload.items.forEach(enrichBootItem);
+  payload.items.forEach((item) => {
+    enrichBootItem(item);
+    enrichShieldItem(item);
+  });
   return payload;
 }

--- a/api/src/utils/character-stats.test.ts
+++ b/api/src/utils/character-stats.test.ts
@@ -28,7 +28,8 @@ function createMockCharacter(items: IItem[]): CharacterResp {
 function createMockItem(
   name: string,
   properties: string[],
-  equipment: string = "Body Armor"
+  equipment: string = "Body Armor",
+  modifiers: IItem["modifiers"] = []
 ): IItem {
   return {
     name,
@@ -36,6 +37,7 @@ function createMockItem(
     base_item: { name: "Test Base", id: 1 },
     location: { equipment, x: 0, y: 0, width: 2, height: 3 },
     properties,
+    modifiers,
   } as unknown as IItem;
 }
 
@@ -522,12 +524,41 @@ describe("StatParser", () => {
     });
 
     it("should parse deadly strike", () => {
-      const items = [createMockItem("Item1", ["+33% Deadly Strike"])];
+      const items = [
+        createMockItem("Item1", ["33% Chance of Deadly Strike"]),
+      ];
       const char = createMockCharacter(items);
       const parser = new CharacterStatParser(char);
       const stats = parser.parseAndGetCharStats();
 
       expect(stats.deadlyStrike).toBe(33);
+    });
+
+    it("should parse critical strike", () => {
+      const items = [
+        createMockItem("Item1", ["16% Chance of Critical Strike"]),
+      ];
+      const char = createMockCharacter(items);
+      const parser = new CharacterStatParser(char);
+      const stats = parser.parseAndGetCharStats();
+
+      expect(stats.criticalStrike).toBe(16);
+    });
+
+    it("should scale per-level deadly strike from item modifiers", () => {
+      const items = [
+        createMockItem("Item1", [], "Amulet", [
+          {
+            name: "deadly/lvl",
+            values: [0, 0, 0.25],
+          },
+        ] as IItem["modifiers"]),
+      ];
+      const char = createMockCharacter(items);
+      const parser = new CharacterStatParser(char);
+      const stats = parser.parseAndGetCharStats();
+
+      expect(stats.deadlyStrike).toBe(22);
     });
 
     it("should parse open wounds", () => {

--- a/api/src/utils/character-stats.ts
+++ b/api/src/utils/character-stats.ts
@@ -1,4 +1,5 @@
 import { CharacterData, CharStats } from "../types";
+import { expandItemStats } from "./item-stat-expansion";
 
 export default class CharacterStatParser {
   private character: CharacterData;
@@ -35,6 +36,7 @@ export default class CharacterStatParser {
       fasterHitRecovery: 0,
 
       crushingBlow: 0,
+      criticalStrike: 0,
       deadlyStrike: 0,
       lifeLeech: 0,
       manaLeech: 0,
@@ -71,6 +73,14 @@ export default class CharacterStatParser {
     else return null;
   }
 
+  private sumMatches(regex: RegExp, properties: (string | null)[]): number {
+    return properties.reduce((total, property) => {
+      if (!property) return total;
+      const match = property.match(regex);
+      return total + (match ? Number(match[1]) : 0);
+    }, 0);
+  }
+
   public parseAndGetCharStats(): CharStats {
     for (const item of this.character.items) {
       if (
@@ -79,6 +89,30 @@ export default class CharacterStatParser {
       ) {
         continue;
       }
+
+      const expandedStats = expandItemStats(item);
+      const criticalStrike =
+        expandedStats.item_crit_chance ||
+        this.sumMatches(
+          /^(?:\+)?([\d.]+)% (?:Chance of )?Critical Strike$/i,
+          item.properties
+        );
+      const deadlyStrike =
+        expandedStats.item_deadlystrike ||
+        this.sumMatches(
+          /^(?:\+)?([\d.]+)% (?:Chance of )?Deadly Strike$/i,
+          item.properties
+        );
+      const deadlyStrikePerLevel =
+        expandedStats.item_deadlystrike_perlevel ||
+        this.sumMatches(
+          /^(?:\+)?([\d.]+)% (?:Chance of )?Deadly Strike \(Based on Character Level\)$/i,
+          item.properties
+        );
+      this.characterStats.criticalStrike += criticalStrike;
+      this.characterStats.deadlyStrike +=
+        deadlyStrike +
+        Math.floor(deadlyStrikePerLevel * this.character.character.level);
 
       for (const property of item.properties) {
         // All Resistances (applies to all)
@@ -292,12 +326,6 @@ export default class CharacterStatParser {
         );
         if (crushingBlow) {
           this.characterStats.crushingBlow += crushingBlow;
-          continue;
-        }
-
-        const deadlyStrike = this.matchInt(/(\d+)% Deadly Strike/, property);
-        if (deadlyStrike) {
-          this.characterStats.deadlyStrike += deadlyStrike;
           continue;
         }
 

--- a/api/src/utils/damage-calculator.test.ts
+++ b/api/src/utils/damage-calculator.test.ts
@@ -1316,6 +1316,43 @@ describeWithGameData("damage calculator component model", () => {
     );
   });
 
+  it("does not apply Critical or Deadly Strike to the War Cry physical spell", () => {
+    const createWarCryCharacter = (withStrikeModifiers: boolean) => {
+      const character = createCharacter("War Cry", 20);
+      character.character.class = { id: 4, name: "Barbarian" };
+      character.items[0].modifiers = withStrikeModifiers
+        ? [
+            modifier("item_crit_chance", [100]),
+            modifier("item_deadlystrike", [100]),
+          ]
+        : [];
+      return character;
+    };
+    const controlProfile = calculateDamage(
+      createWarCryCharacter(false)
+    ).profiles.find(
+      (candidate) =>
+        candidate.skillId === "War Cry" && candidate.playerAuraId === "none"
+    )!;
+    const strikeProfile = calculateDamage(
+      createWarCryCharacter(true)
+    ).profiles.find(
+      (candidate) =>
+        candidate.skillId === "War Cry" && candidate.playerAuraId === "none"
+    )!;
+
+    expect(strikeProfile.skillDamageMode).toBe("spell");
+    expect(strikeProfile.strikeBreakdowns).toEqual([]);
+    expect(
+      strikeProfile.damageComponents.some((component) =>
+        ["critical", "deadly"].includes(component.damageType)
+      )
+    ).toBe(false);
+    expect(strikeProfile.damageTotals.combinedDamage).toEqual(
+      controlProfile.damageTotals.combinedDamage
+    );
+  });
+
   it("keeps Rabies weapon source damage and poison payload as independent components", () => {
     const calculation = calculateDamage(createCharacter("Rabies", 20));
     const rabiesProfile = calculation.profiles.find(
@@ -4440,69 +4477,146 @@ describeWithArmorData("armory payload attack enrichment", () => {
     expect(payload.items[0].base.stat_bonus).toEqual({ strength: 100 });
   });
 
-  it("adds Armor.txt shield and Holy Shield damage to Smite before physical multipliers", () => {
-    const smiteLevel = 20;
-    const holyShieldLevel = 20;
-    const defianceBaseLevel = 10;
-    const strength = 100;
-    const weaponDamageBonus = 10;
+  function createSmiteCharacter({
+    smiteLevel = 20,
+    smiteBaseLevel = smiteLevel,
+    holyShieldLevel = 0,
+    holyShieldBaseLevel = holyShieldLevel,
+    defianceLevel = 0,
+    defianceBaseLevel = defianceLevel,
+    strength = 0,
+  } = {}) {
     const character = createCharacter("Smite", smiteLevel);
     character.character.class = { id: 3, name: "Paladin" };
     character.character.attributes.strength = strength;
     character.character.skills = [
       { id: 97, name: "Smite", level: smiteLevel },
-      { id: 117, name: "Holy Shield", level: holyShieldLevel },
-      { id: 104, name: "Defiance", level: defianceBaseLevel },
+      ...(holyShieldLevel > 0
+        ? [{ id: 117, name: "Holy Shield", level: holyShieldLevel }]
+        : []),
+      ...(defianceLevel > 0
+        ? [{ id: 104, name: "Defiance", level: defianceLevel }]
+        : []),
     ];
     character.realSkills = [
-      { skill: "Smite", level: smiteLevel, baseLevel: smiteLevel },
-      {
-        skill: "Holy Shield",
-        level: holyShieldLevel,
-        baseLevel: holyShieldLevel,
-      },
-      {
-        skill: "Defiance",
-        level: defianceBaseLevel,
-        baseLevel: defianceBaseLevel,
-      },
+      { skill: "Smite", level: smiteLevel, baseLevel: smiteBaseLevel },
+      ...(holyShieldLevel > 0
+        ? [
+            {
+              skill: "Holy Shield",
+              level: holyShieldLevel,
+              baseLevel: holyShieldBaseLevel,
+            },
+          ]
+        : []),
+      ...(defianceLevel > 0
+        ? [
+            {
+              skill: "Defiance",
+              level: defianceLevel,
+              baseLevel: defianceBaseLevel,
+            },
+          ]
+        : []),
     ];
     character.realStats = { ...createStats(), strength };
-    character.items = [
-      createWeapon({
-        modifiers: [
-          modifier("item_normaldamage", [weaponDamageBonus]),
-          modifier("item_crit_chance", [100]),
-          modifier("item_deadlystrike", [100]),
-        ],
-      }),
-      createShield({
-        properties: [
-          "+20 to Minimum Damage",
-          "Adds 50-100 Fire Damage",
-        ],
-      }),
-    ];
+    return character;
+  }
 
-    enrichArmoryPayload(character);
-    const calculation = calculateDamage(character);
-    const profile = calculation.profiles.find(
-      (candidate) =>
-        candidate.skillId === "Smite" && candidate.playerAuraId === "none"
-    )!;
-    const holyFireProfile = calculation.profiles.find(
+  function getShieldDamage(code = "pab") {
+    const armor = loadGameFile("Armor.txt", "code");
+    const row = armor.rowsByKey.get(code)!;
+    return {
+      min: getGameFileNumber(armor, row, "mindam"),
+      max: getGameFileNumber(armor, row, "maxdam"),
+    };
+  }
+
+  function getSmiteProfile(calculation, weaponSet = "primary") {
+    return calculation.profiles.find(
       (candidate) =>
         candidate.skillId === "Smite" &&
-        candidate.playerAuraId === "Holy Fire" &&
-        candidate.playerAuraCarrier === "self"
+        candidate.playerAuraId === "none" &&
+        candidate.weaponId.startsWith(`${weaponSet}:left:smite:`)
     )!;
+  }
 
-    const armor = loadGameFile("Armor.txt", "code");
-    const shieldRow = armor.rowsByKey.get("pab")!;
-    const shieldDamage = {
-      min: getGameFileNumber(armor, shieldRow, "mindam"),
-      max: getGameFileNumber(armor, shieldRow, "maxdam"),
+  it("enriches an equipped shield with Armor.txt Smite damage", () => {
+    const payload = { items: [createShield()] };
+    const shieldDamage = getShieldDamage();
+
+    enrichArmoryPayload(payload);
+
+    expect(payload.items[0].base.damage?.smite).toEqual({
+      minimum: shieldDamage.min,
+      maximum: shieldDamage.max,
+    });
+    expect(payload.items[0].damage?.smite).toEqual({
+      minimum: shieldDamage.min,
+      maximum: shieldDamage.max,
+    });
+    expect(payload.items[0].base.stat_bonus).toEqual({ strength: 100 });
+  });
+
+  it("uses shield base damage and weapon Damage +X for Smite", () => {
+    const smiteLevel = 20;
+    const weaponDamageBonus = 10;
+    const character = createSmiteCharacter({ smiteLevel });
+    character.items = [
+      createWeapon({
+        modifiers: [modifier("item_normaldamage", [weaponDamageBonus])],
+      }),
+      createShield(),
+    ];
+    enrichArmoryPayload(character);
+
+    const profile = getSmiteProfile(calculateDamage(character));
+    const shieldDamage = getShieldDamage();
+    const skills = loadGameFile("Skills.txt", "skill");
+    const smiteRow = skills.rowsByKey.get("Smite")!;
+    const smiteDamagePercent =
+      getGameFileNumber(skills, smiteRow, "Param3") +
+      (smiteLevel - 1) * getGameFileNumber(skills, smiteRow, "Param4");
+    const expectedDamage = {
+      min: Math.floor(
+        (shieldDamage.min + weaponDamageBonus) *
+          (1 + smiteDamagePercent / 100)
+      ),
+      max: Math.floor(
+        (shieldDamage.max + weaponDamageBonus) *
+          (1 + smiteDamagePercent / 100)
+      ),
     };
+
+    expect(profile.weaponId).toContain(":left:smite:");
+    expect(profile.damageScope.label).toBe("per shield hit");
+    expect(profile.breakdown.weaponDamage).toEqual(shieldDamage);
+    expect(profile.breakdown.flatPhysicalDamage).toEqual({
+      min: weaponDamageBonus,
+      max: weaponDamageBonus,
+    });
+    expect(profile.totalPhysicalDamage).toEqual(expectedDamage);
+  });
+
+  it("uses Holy Shield effective level and Smite/Defiance base levels for its synergy", () => {
+    const smiteLevel = 30;
+    const smiteBaseLevel = 20;
+    const holyShieldLevel = 30;
+    const defianceLevel = 25;
+    const defianceBaseLevel = 10;
+    const character = createSmiteCharacter({
+      smiteLevel,
+      smiteBaseLevel,
+      holyShieldLevel,
+      holyShieldBaseLevel: 20,
+      defianceLevel,
+      defianceBaseLevel,
+    });
+    character.items = [createWeapon(), createShield()];
+    enrichArmoryPayload(character);
+
+    const calculation = calculateDamage(character);
+    const profile = getSmiteProfile(calculation);
     const skills = loadGameFile("Skills.txt", "skill");
     const holyShieldRow = skills.rowsByKey.get("Holy Shield")!;
     const holyShieldBaseDamage = {
@@ -4521,47 +4635,73 @@ describeWithArmorData("armory payload attack enrichment", () => {
         ["MaxLevDam1", "MaxLevDam2", "MaxLevDam3", "MaxLevDam4", "MaxLevDam5"]
       ),
     };
-    const holyShieldSynergyPercent =
-      (smiteLevel + defianceBaseLevel) *
-      getGameFileNumber(skills, holyShieldRow, "Param7");
-    const holyShieldDamage = {
+    const synergyPerLevel = getGameFileNumber(
+      skills,
+      holyShieldRow,
+      "Param7"
+    );
+    const expectedSynergyPercent =
+      (smiteBaseLevel + defianceBaseLevel) * synergyPerLevel;
+    const incorrectSoftLevelSynergyPercent =
+      (smiteLevel + defianceLevel) * synergyPerLevel;
+    const expectedHolyShieldDamage = {
       min: Math.floor(
-        holyShieldBaseDamage.min * (1 + holyShieldSynergyPercent / 100)
+        holyShieldBaseDamage.min * (1 + expectedSynergyPercent / 100)
       ),
       max: Math.floor(
-        holyShieldBaseDamage.max * (1 + holyShieldSynergyPercent / 100)
+        holyShieldBaseDamage.max * (1 + expectedSynergyPercent / 100)
       ),
     };
-    const smiteRow = skills.rowsByKey.get("Smite")!;
-    const smiteDamagePercent =
-      getGameFileNumber(skills, smiteRow, "Param3") +
-      (smiteLevel - 1) * getGameFileNumber(skills, smiteRow, "Param4");
-    const smiteBaseDamage = {
-      min: shieldDamage.min + holyShieldDamage.min + weaponDamageBonus,
-      max: shieldDamage.max + holyShieldDamage.max + weaponDamageBonus,
-    };
-    const expectedDamage = {
+    const incorrectSoftLevelDamage = {
       min: Math.floor(
-        smiteBaseDamage.min * (1 + (strength + smiteDamagePercent) / 100)
+        holyShieldBaseDamage.min *
+          (1 + incorrectSoftLevelSynergyPercent / 100)
       ),
       max: Math.floor(
-        smiteBaseDamage.max * (1 + (strength + smiteDamagePercent) / 100)
+        holyShieldBaseDamage.max *
+          (1 + incorrectSoftLevelSynergyPercent / 100)
       ),
     };
 
-    expect(character.items[1].base.damage?.smite).toEqual({
-      minimum: shieldDamage.min,
-      maximum: shieldDamage.max,
-    });
-    expect(profile).toBeDefined();
-    expect(profile.weaponId).toContain(":left:smite:");
-    expect(profile.damageScope.label).toBe("per shield hit");
-    expect(profile.breakdown.weaponDamage).toEqual(shieldDamage);
-    expect(profile.breakdown.flatPhysicalDamage).toEqual({
-      min: holyShieldDamage.min + weaponDamageBonus,
-      max: holyShieldDamage.max + weaponDamageBonus,
-    });
-    expect(profile.totalPhysicalDamage).toEqual(expectedDamage);
+    expect(profile.breakdown.flatPhysicalDamage).toEqual(
+      expectedHolyShieldDamage
+    );
+    expect(profile.breakdown.flatPhysicalDamage).not.toEqual(
+      incorrectSoftLevelDamage
+    );
+    expect(
+      calculation.skillOptions.some((option) => option.id === "Holy Shield")
+    ).toBe(false);
+    expect(profile.notes.join(" ")).toContain(
+      `Holy Shield level ${holyShieldLevel} damage is added to the shield base`
+    );
+  });
+
+  it("excludes elemental payloads and Critical/Deadly Strike from Smite", () => {
+    const character = createSmiteCharacter();
+    character.items = [
+      createWeapon({
+        modifiers: [
+          modifier("item_crit_chance", [100]),
+          modifier("item_deadlystrike", [100]),
+        ],
+      }),
+      createShield({
+        properties: ["Adds 50-100 Fire Damage"],
+      }),
+    ];
+    enrichArmoryPayload(character);
+
+    const calculation = calculateDamage(character);
+    const profile = getSmiteProfile(calculation);
+    const holyFireProfile = calculation.profiles.find(
+      (candidate) =>
+        candidate.skillId === "Smite" &&
+        candidate.playerAuraId === "Holy Fire" &&
+        candidate.playerAuraCarrier === "self" &&
+        candidate.weaponId.startsWith("primary:left:smite:")
+    )!;
+
     expect(profile.totalElementalDamage).toEqual({});
     expect(holyFireProfile.totalElementalDamage).toEqual({});
     expect(profile.strikeBreakdowns).toEqual([]);
@@ -4570,11 +4710,54 @@ describeWithArmorData("armory payload attack enrichment", () => {
         ["critical", "deadly", "fire"].includes(component.damageType)
       )
     ).toBe(false);
-    expect(
-      calculation.skillOptions.some((option) => option.id === "Holy Shield")
-    ).toBe(false);
-    expect(profile.notes.join(" ")).toContain(
-      "Holy Shield level 20 damage is added to the shield base"
+  });
+
+  it("uses the shield from the selected primary or secondary weapon set", () => {
+    const primaryShield = createShield({
+      id: "primary-shield",
+      hash: "primary-shield",
+    });
+    const secondaryShield = createShield({
+      id: "secondary-shield",
+      hash: "secondary-shield",
+      name: "Test Buckler",
+      base_code: "buc",
+      base: {
+        id: "buc",
+        category: "armor",
+        codes: {},
+        name: "Buckler",
+        stackable: false,
+        type: "Shields",
+        type_code: "shie",
+        size: { height: 2, width: 2 },
+        requirements: { level: 0, strength: 12, dexterity: 0 },
+      },
+      location: {
+        zone: "Equipped",
+        storage: "Equipped",
+        zone_id: 1,
+        storage_id: 0,
+        equipment: "Left Hand Switch",
+        equipment_id: 12,
+      },
+    });
+    const character = createSmiteCharacter();
+    character.items = [createWeapon(), primaryShield, secondaryShield];
+    enrichArmoryPayload(character);
+
+    const calculation = calculateDamage(character);
+    const primaryProfile = getSmiteProfile(calculation, "primary");
+    const secondaryProfile = getSmiteProfile(calculation, "secondary");
+
+    expect(primaryProfile.breakdown.weaponDamage).toEqual(
+      getShieldDamage("pab")
+    );
+    expect(secondaryProfile.breakdown.weaponDamage).toEqual(
+      getShieldDamage("buc")
+    );
+    expect(primaryProfile.breakdown.weaponDamage).not.toEqual(
+      secondaryProfile.breakdown.weaponDamage
     );
   });
 });

--- a/api/src/utils/damage-calculator.test.ts
+++ b/api/src/utils/damage-calculator.test.ts
@@ -73,6 +73,15 @@ function createStats() {
   };
 }
 
+function modifier(name: string, values: Array<number | string> = []) {
+  return {
+    name,
+    values,
+    label: "",
+    priority: 0,
+  };
+}
+
 function expectPhysicalBonusTotalToMatchBuckets(profile) {
   const bonus = profile.breakdown.physicalBonusPercent;
   const expectedTotal =
@@ -175,6 +184,56 @@ function createBoot(overrides: Partial<IItem> = {}): IItem {
       storage_id: 0,
       equipment: "Boots",
       equipment_id: 9,
+    },
+    position: { row: 0, column: 0 },
+    properties: [],
+    is_identified: true,
+    is_socketed: false,
+    is_new: false,
+    is_ear: false,
+    is_starter: false,
+    is_simple: true,
+    is_ethereal: false,
+    is_personalized: false,
+    is_runeword: false,
+    socketed_count: 0,
+    item_level: 1,
+    graphic_id: 0,
+    class_specifics: false,
+    socket_count: 0,
+    modifiers: [],
+    corrupted: false,
+    desecrated: false,
+    ...overrides,
+  } as unknown as IItem;
+}
+
+function createShield(overrides: Partial<IItem> = {}): IItem {
+  return {
+    id: overrides.id ?? "test-shield",
+    hash: overrides.hash ?? "test-shield",
+    name: overrides.name ?? "Test Sacred Targe",
+    category: "armor",
+    base_code: "pab",
+    base: {
+      id: "pab",
+      category: "armor",
+      codes: {},
+      name: "Sacred Targe",
+      stackable: false,
+      type: "Auric Shields",
+      type_code: "ashd",
+      size: { height: 2, width: 2 },
+      requirements: { level: 47, strength: 86, dexterity: 0 },
+    },
+    quality: { id: 2, name: "Normal" },
+    location: overrides.location ?? {
+      zone: "Equipped",
+      storage: "Equipped",
+      zone_id: 1,
+      storage_id: 0,
+      equipment: "Left Hand",
+      equipment_id: 5,
     },
     position: { row: 0, column: 0 },
     properties: [],
@@ -909,6 +968,352 @@ function getExpectedSkeletonArcherDirectPhysicalFromGameFiles({
 describeWithGameData("damage calculator component model", () => {
   beforeAll(async () => {
     ({ calculateDamage } = await import("./damage-calculator"));
+  });
+
+  it("models capped Critical and Deadly Strike as separate expected damage", () => {
+    const character = createCharacter("Basic Attack", 1);
+    character.items[0].modifiers = [
+      modifier("item_crit_chance", [100]),
+      modifier("item_deadlystrike", [100]),
+      modifier("item_maxdeadlystrike", [50]),
+      modifier("item_crit_multiplier", [25]),
+      modifier("item_ds_multiplier", [50]),
+    ];
+
+    const calculation = calculateDamage(character);
+    const profile = calculation.profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+    const strike = profile.strikeBreakdowns[0];
+    const critical = profile.damageComponents.find(
+      (component) => component.damageType === "critical"
+    );
+    const deadly = profile.damageComponents.find(
+      (component) => component.damageType === "deadly"
+    );
+
+    expect(strike).toMatchObject({
+      rawCriticalChance: 100,
+      criticalChance: 75,
+      criticalMultiplier: 2.25,
+      rawDeadlyStrikeChance: 100,
+      rawMaxDeadlyStrikeChance: 125,
+      deadlyStrikeChance: 100,
+      maxDeadlyStrikeChance: 100,
+      effectiveDeadlyStrikeChance: 25,
+      deadlyStrikeMultiplier: 2,
+    });
+    expect(critical?.damage).toEqual({ min: 9.375, max: 18.75 });
+    expect(deadly?.damage).toEqual({ min: 2.5, max: 5 });
+    expect(critical?.label).toBe("Critical Strike bonus");
+    expect(deadly?.label).toBe("Deadly Strike bonus");
+    expect(profile.damageTotals.byElement.critical).toEqual(critical?.damage);
+    expect(profile.damageTotals.byElement.deadly).toEqual(deadly?.damage);
+    expect(profile.damageTotals.combinedDamage).toEqual({
+      min: 21.875,
+      max: 43.75,
+    });
+  });
+
+  it("uses decoded per-level Deadly Strike values and text fallback", () => {
+    const perLevelCharacter = createCharacter("Basic Attack", 1);
+    perLevelCharacter.items[0].modifiers = [
+      modifier("item_deadlystrike", [20]),
+      modifier("item_deadlystrike_perlevel", [0.375]),
+    ];
+
+    const perLevelProfile = calculateDamage(perLevelCharacter).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+
+    expect(perLevelProfile.strikeBreakdowns[0]).toMatchObject({
+      rawDeadlyStrikeChance: 53,
+      deadlyStrikeChance: 53,
+      effectiveDeadlyStrikeChance: 53,
+    });
+    const perLevelDeadlyDamage = perLevelProfile.damageComponents.find(
+      (component) => component.damageType === "deadly"
+    )!.damage;
+    expect(perLevelDeadlyDamage.min).toBeCloseTo(2.65);
+    expect(perLevelDeadlyDamage.max).toBeCloseTo(5.3);
+
+    const textCharacter = createCharacter("Basic Attack", 1);
+    textCharacter.items[0].properties = [
+      "+35% Chance of Deadly Strike",
+      "+25% Deadly Strike Multiplier",
+    ];
+    const textProfile = calculateDamage(textCharacter).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+
+    expect(textProfile.strikeBreakdowns[0]).toMatchObject({
+      rawDeadlyStrikeChance: 35,
+      deadlyStrikeMultiplier: 1.75,
+    });
+
+    textCharacter.items[0].properties = [
+      "0.375% Chance of Deadly Strike (Based on Character Level)",
+    ];
+    const perLevelTextProfile = calculateDamage(textCharacter).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+    expect(perLevelTextProfile.strikeBreakdowns[0].rawDeadlyStrikeChance).toBe(
+      33
+    );
+  });
+
+  it("applies file-backed passive strike stats only to compatible weapons", () => {
+    const criticalLevel = 20;
+    const skills = loadGameFile("Skills.txt", "skill");
+    const criticalRow = skills.rowsByKey.get("Critical Strike")!;
+    const criticalMin = getGameFileNumber(skills, criticalRow, "Param1");
+    const criticalMax = getGameFileNumber(skills, criticalRow, "Param2");
+    const scale = Math.floor((110 * criticalLevel) / (criticalLevel + 6));
+    const expectedCriticalChance = Math.min(
+      criticalMax,
+      criticalMin + Math.floor(((criticalMax - criticalMin) * scale) / 100)
+    );
+    const character = createCharacter("Critical Strike", criticalLevel);
+    character.character.class = { id: 0, name: "Amazon" };
+    character.character.skills = [
+      { id: 9, name: "Critical Strike", level: criticalLevel },
+    ];
+    character.realSkills = [
+      {
+        skill: "Critical Strike",
+        level: criticalLevel,
+        baseLevel: criticalLevel,
+      },
+    ];
+
+    const clubProfile = calculateDamage(character).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+    expect(clubProfile.strikeBreakdowns[0].criticalChance).toBe(0);
+
+    character.items = [
+      createWeapon({
+        id: "test-spear",
+        hash: "test-spear",
+        name: "Test Spear",
+        base_code: "spr",
+        base: {
+          ...createWeapon().base,
+          id: "spr",
+          name: "Spear",
+          type: "Spear",
+          type_code: "spea",
+        },
+      } as Partial<IItem>),
+    ];
+    const spearProfile = calculateDamage(character).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+
+    expect(spearProfile.strikeBreakdowns[0].criticalChance).toBe(
+      expectedCriticalChance
+    );
+  });
+
+  it("uses S13 mastery and Joust strike formulas from Skills.txt", () => {
+    const masteryLevel = 20;
+    const javelinMasteryCharacter = createCharacter(
+      "Javelin and Spear Mastery",
+      masteryLevel
+    );
+    javelinMasteryCharacter.character.class = { id: 0, name: "Amazon" };
+    javelinMasteryCharacter.character.skills = [
+      {
+        id: 19,
+        name: "Javelin and Spear Mastery",
+        level: masteryLevel,
+      },
+    ];
+    javelinMasteryCharacter.realSkills = [
+      {
+        skill: "Javelin and Spear Mastery",
+        level: masteryLevel,
+        baseLevel: masteryLevel,
+      },
+    ];
+    const offWeaponMasteryProfile = calculateDamage(
+      javelinMasteryCharacter
+    ).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+    expect(offWeaponMasteryProfile.strikeBreakdowns[0]).toMatchObject({
+      criticalChance: 0,
+      criticalMultiplier: 2.29,
+    });
+
+    const oneHandCharacter = createCharacter("One Hand Mastery", masteryLevel);
+    oneHandCharacter.character.class = { id: 4, name: "Barbarian" };
+    oneHandCharacter.character.skills = [
+      { id: 128, name: "One Hand Mastery", level: masteryLevel },
+    ];
+    oneHandCharacter.realSkills = [
+      {
+        skill: "One Hand Mastery",
+        level: masteryLevel,
+        baseLevel: masteryLevel,
+      },
+    ];
+    const oneHandProfile = calculateDamage(oneHandCharacter).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+    expect(oneHandProfile.strikeBreakdowns[0].criticalChance).toBeGreaterThan(
+      0
+    );
+    oneHandCharacter.character.skills.push({
+      id: 128,
+      name: "One Handed Mastery",
+      level: masteryLevel,
+    });
+    const aliasedMasteryProfile = calculateDamage(
+      oneHandCharacter
+    ).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+    expect(aliasedMasteryProfile.strikeBreakdowns[0].criticalChance).toBe(
+      oneHandProfile.strikeBreakdowns[0].criticalChance
+    );
+
+    const twoHandCharacter = createCharacter("Two Hand Mastery", masteryLevel);
+    twoHandCharacter.character.class = { id: 4, name: "Barbarian" };
+    twoHandCharacter.character.skills = [
+      { id: 134, name: "Two Hand Mastery", level: masteryLevel },
+    ];
+    twoHandCharacter.realSkills = [
+      {
+        skill: "Two Hand Mastery",
+        level: masteryLevel,
+        baseLevel: masteryLevel,
+      },
+    ];
+    twoHandCharacter.items = [
+      createWeapon({
+        damage: {
+          one_handed: {},
+          two_handed: { minimum: 10, maximum: 20 },
+          missile: {},
+        },
+      } as Partial<IItem>),
+    ];
+    const twoHandProfile = calculateDamage(twoHandCharacter).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Basic Attack" &&
+        candidate.playerAuraId === "none"
+    )!;
+    expect(twoHandProfile.strikeBreakdowns[0].criticalChance).toBe(0);
+
+    const joustLevel = 20;
+    const joustCharacter = createCharacter("Joust", joustLevel);
+    joustCharacter.character.class = { id: 3, name: "Paladin" };
+    joustCharacter.character.skills = [
+      { id: 378, name: "Joust", level: joustLevel },
+    ];
+    joustCharacter.realSkills = [
+      { skill: "Joust", level: joustLevel, baseLevel: joustLevel },
+    ];
+    const joustProfile = calculateDamage(joustCharacter).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Joust" && candidate.playerAuraId === "none"
+    )!;
+    expect(joustProfile.strikeBreakdowns[0].criticalChance).toBe(48);
+  });
+
+  it("exposes Blessed Aim and Spirit of Barbs strike bonuses by aura level", () => {
+    const level = 20;
+    const character = createCharacter("Basic Attack", 1);
+    character.character.skills = [
+      { id: 108, name: "Blessed Aim", level },
+      { id: 246, name: "Spirit of Barbs", level },
+    ];
+    character.realSkills = character.character.skills.map((skill) => ({
+      skill: skill.name,
+      level: skill.level,
+      baseLevel: skill.level,
+    }));
+
+    const calculation = calculateDamage(character);
+    const blessedAim = calculation.playerAuraOptions.find(
+      (option) => option.id === "Blessed Aim"
+    )!;
+    const spiritOfBarbs = calculation.playerAuraOptions.find(
+      (option) => option.id === "Spirit of Barbs"
+    )!;
+
+    expect(
+      blessedAim.selfLevelBonuses.find((bonus) => bonus.level === level)
+        ?.strikeModifiers
+    ).toMatchObject({ deadlyStrikeChance: 15 });
+    expect(
+      spiritOfBarbs.selfLevelBonuses.find((bonus) => bonus.level === level)
+        ?.strikeModifiers
+    ).toMatchObject({
+      deadlyStrikeChance: 27,
+      maxDeadlyStrikeChance: 5,
+    });
+
+    const blessedAimProfile = calculation.profiles.find(
+      (profile) =>
+        profile.skillId === "Basic Attack" &&
+        profile.playerAuraId === "Blessed Aim" &&
+        profile.playerAuraCarrier === "self"
+    )!;
+    const spiritProfile = calculation.profiles.find(
+      (profile) =>
+        profile.skillId === "Basic Attack" &&
+        profile.playerAuraId === "Spirit of Barbs" &&
+        profile.playerAuraCarrier === "self"
+    )!;
+    expect(blessedAimProfile.strikeBreakdowns[0].deadlyStrikeChance).toBe(15);
+    expect(spiritProfile.strikeBreakdowns[0]).toMatchObject({
+      deadlyStrikeChance: 27,
+      maxDeadlyStrikeChance: 80,
+    });
+  });
+
+  it("excludes Critical and Deadly Strike from Sacrifice", () => {
+    const character = createCharacter("Sacrifice", 20);
+    character.character.class = { id: 3, name: "Paladin" };
+    character.items[0].modifiers = [
+      modifier("item_crit_chance", [50]),
+      modifier("item_deadlystrike", [50]),
+    ];
+
+    const profile = calculateDamage(character).profiles.find(
+      (candidate) =>
+        candidate.skillId === "Sacrifice" && candidate.playerAuraId === "none"
+    )!;
+
+    expect(profile.strikeBreakdowns).toEqual([]);
+    expect(
+      profile.damageComponents.some((component) =>
+        ["critical", "deadly"].includes(component.damageType)
+      )
+    ).toBe(false);
+    expect(profile.notes.join(" ")).toContain(
+      "does not benefit from Critical Strike or Deadly Strike"
+    );
   });
 
   it("keeps Rabies weapon source damage and poison payload as independent components", () => {
@@ -2745,6 +3150,7 @@ describeWithGameData("damage calculator component model", () => {
         id: "right-weapon",
         hash: "right-weapon",
         name: "Right Club",
+        modifiers: [modifier("item_deadlystrike", [50])],
         damage: {
           one_handed: { minimum: 10, maximum: 20 },
           two_handed: {},
@@ -2805,6 +3211,18 @@ describeWithGameData("damage calculator component model", () => {
         leftProfile!.damageTotals.combinedDamage.max,
     });
     expect(sequenceProfile?.notes.join(" ")).toContain("weapsel=2");
+    expect(rightProfile?.strikeBreakdowns[0].deadlyStrikeChance).toBe(50);
+    expect(leftProfile?.strikeBreakdowns[0].deadlyStrikeChance).toBe(0);
+    expect(
+      sequenceProfile?.strikeBreakdowns.map(
+        (breakdown) => breakdown.deadlyStrikeChance
+      )
+    ).toEqual([50, 0]);
+    expect(
+      sequenceProfile?.damageComponents.filter(
+        (component) => component.damageType === "deadly"
+      )
+    ).toHaveLength(1);
   });
 
   it("restricts required dual-wield skills to paired weapon profiles", () => {
@@ -3983,8 +4401,9 @@ describeWithMonStatsData("summon damage modeling", () => {
   });
 });
 
-describeWithArmorData("armory payload kick enrichment", () => {
+describeWithArmorData("armory payload attack enrichment", () => {
   beforeAll(async () => {
+    ({ calculateDamage } = await import("./damage-calculator"));
     ({ enrichArmoryPayload } = await import("./armory-payload"));
   });
 
@@ -4019,5 +4438,143 @@ describeWithArmorData("armory payload kick enrichment", () => {
       maximum: 147,
     });
     expect(payload.items[0].base.stat_bonus).toEqual({ strength: 100 });
+  });
+
+  it("adds Armor.txt shield and Holy Shield damage to Smite before physical multipliers", () => {
+    const smiteLevel = 20;
+    const holyShieldLevel = 20;
+    const defianceBaseLevel = 10;
+    const strength = 100;
+    const weaponDamageBonus = 10;
+    const character = createCharacter("Smite", smiteLevel);
+    character.character.class = { id: 3, name: "Paladin" };
+    character.character.attributes.strength = strength;
+    character.character.skills = [
+      { id: 97, name: "Smite", level: smiteLevel },
+      { id: 117, name: "Holy Shield", level: holyShieldLevel },
+      { id: 104, name: "Defiance", level: defianceBaseLevel },
+    ];
+    character.realSkills = [
+      { skill: "Smite", level: smiteLevel, baseLevel: smiteLevel },
+      {
+        skill: "Holy Shield",
+        level: holyShieldLevel,
+        baseLevel: holyShieldLevel,
+      },
+      {
+        skill: "Defiance",
+        level: defianceBaseLevel,
+        baseLevel: defianceBaseLevel,
+      },
+    ];
+    character.realStats = { ...createStats(), strength };
+    character.items = [
+      createWeapon({
+        modifiers: [
+          modifier("item_normaldamage", [weaponDamageBonus]),
+          modifier("item_crit_chance", [100]),
+          modifier("item_deadlystrike", [100]),
+        ],
+      }),
+      createShield({
+        properties: [
+          "+20 to Minimum Damage",
+          "Adds 50-100 Fire Damage",
+        ],
+      }),
+    ];
+
+    enrichArmoryPayload(character);
+    const calculation = calculateDamage(character);
+    const profile = calculation.profiles.find(
+      (candidate) =>
+        candidate.skillId === "Smite" && candidate.playerAuraId === "none"
+    )!;
+    const holyFireProfile = calculation.profiles.find(
+      (candidate) =>
+        candidate.skillId === "Smite" &&
+        candidate.playerAuraId === "Holy Fire" &&
+        candidate.playerAuraCarrier === "self"
+    )!;
+
+    const armor = loadGameFile("Armor.txt", "code");
+    const shieldRow = armor.rowsByKey.get("pab")!;
+    const shieldDamage = {
+      min: getGameFileNumber(armor, shieldRow, "mindam"),
+      max: getGameFileNumber(armor, shieldRow, "maxdam"),
+    };
+    const skills = loadGameFile("Skills.txt", "skill");
+    const holyShieldRow = skills.rowsByKey.get("Holy Shield")!;
+    const holyShieldBaseDamage = {
+      min: getSourceLevelScaledValue(
+        skills,
+        holyShieldRow,
+        holyShieldLevel,
+        "MinDam",
+        ["MinLevDam1", "MinLevDam2", "MinLevDam3", "MinLevDam4", "MinLevDam5"]
+      ),
+      max: getSourceLevelScaledValue(
+        skills,
+        holyShieldRow,
+        holyShieldLevel,
+        "MaxDam",
+        ["MaxLevDam1", "MaxLevDam2", "MaxLevDam3", "MaxLevDam4", "MaxLevDam5"]
+      ),
+    };
+    const holyShieldSynergyPercent =
+      (smiteLevel + defianceBaseLevel) *
+      getGameFileNumber(skills, holyShieldRow, "Param7");
+    const holyShieldDamage = {
+      min: Math.floor(
+        holyShieldBaseDamage.min * (1 + holyShieldSynergyPercent / 100)
+      ),
+      max: Math.floor(
+        holyShieldBaseDamage.max * (1 + holyShieldSynergyPercent / 100)
+      ),
+    };
+    const smiteRow = skills.rowsByKey.get("Smite")!;
+    const smiteDamagePercent =
+      getGameFileNumber(skills, smiteRow, "Param3") +
+      (smiteLevel - 1) * getGameFileNumber(skills, smiteRow, "Param4");
+    const smiteBaseDamage = {
+      min: shieldDamage.min + holyShieldDamage.min + weaponDamageBonus,
+      max: shieldDamage.max + holyShieldDamage.max + weaponDamageBonus,
+    };
+    const expectedDamage = {
+      min: Math.floor(
+        smiteBaseDamage.min * (1 + (strength + smiteDamagePercent) / 100)
+      ),
+      max: Math.floor(
+        smiteBaseDamage.max * (1 + (strength + smiteDamagePercent) / 100)
+      ),
+    };
+
+    expect(character.items[1].base.damage?.smite).toEqual({
+      minimum: shieldDamage.min,
+      maximum: shieldDamage.max,
+    });
+    expect(profile).toBeDefined();
+    expect(profile.weaponId).toContain(":left:smite:");
+    expect(profile.damageScope.label).toBe("per shield hit");
+    expect(profile.breakdown.weaponDamage).toEqual(shieldDamage);
+    expect(profile.breakdown.flatPhysicalDamage).toEqual({
+      min: holyShieldDamage.min + weaponDamageBonus,
+      max: holyShieldDamage.max + weaponDamageBonus,
+    });
+    expect(profile.totalPhysicalDamage).toEqual(expectedDamage);
+    expect(profile.totalElementalDamage).toEqual({});
+    expect(holyFireProfile.totalElementalDamage).toEqual({});
+    expect(profile.strikeBreakdowns).toEqual([]);
+    expect(
+      profile.damageComponents.some((component) =>
+        ["critical", "deadly", "fire"].includes(component.damageType)
+      )
+    ).toBe(false);
+    expect(
+      calculation.skillOptions.some((option) => option.id === "Holy Shield")
+    ).toBe(false);
+    expect(profile.notes.join(" ")).toContain(
+      "Holy Shield level 20 damage is added to the shield base"
+    );
   });
 });

--- a/api/src/utils/damage-calculator.test.ts
+++ b/api/src/utils/damage-calculator.test.ts
@@ -45,6 +45,7 @@ function createStats() {
     fasterHitRecovery: 0,
     fasterRunWalk: 0,
     crushingBlow: 0,
+    criticalStrike: 0,
     deadlyStrike: 0,
     openWounds: 0,
     openWoundsDPS: 0,

--- a/api/src/utils/damage-calculator.ts
+++ b/api/src/utils/damage-calculator.ts
@@ -1,7 +1,10 @@
 import fs from "fs";
 import path from "path";
 import CharacterStatParser from "./character-stats";
-import { getExpandedItemElementalDamageRanges } from "./item-stat-expansion";
+import {
+  expandItemStats,
+  getExpandedItemElementalDamageRanges,
+} from "./item-stat-expansion";
 import { calculateTotalSkills } from "./skill-calculator";
 import {
   ActiveAuraSummary,
@@ -14,6 +17,8 @@ import {
   DamageProfile,
   DamageRange,
   DamageSourceReference,
+  DamageStrikeBreakdown,
+  DamageStrikeModifiers,
   DamageTotals,
   DamageSkillOption,
   DamageTransformationOption,
@@ -101,6 +106,10 @@ const DEFAULT_DAMAGE_SCOPE: DamageProfile["damageScope"] = {
 };
 
 const SKILL_DAMAGE_SCOPE_DEFINITIONS: Record<string, DamageScopeDefinition> = {
+  [normalizeSkillName("Smite").toLowerCase()]: {
+    label: "per shield hit",
+    note: "Smite totals use the equipped shield's Armor.txt mindam/maxdam plus the active Holy Shield bonus, then apply strength, Smite enhanced damage, off-weapon enhanced damage, and the selected physical aura. Hit chance, crushing blow, target count, and attack rate are not multiplied into totals.",
+  },
   [normalizeSkillName("Charged Strike").toLowerCase()]: {
     label: "per weapon hit plus one bolt",
     countColumn: "calc1",
@@ -581,6 +590,26 @@ const GAME_STATE_TO_TRANSFORMATION_ID: Record<string, string> = {
 };
 
 const EMPTY_SKILL_MAP = new Map<string, SkillEntry>();
+
+const BASE_CRITICAL_STRIKE_CHANCE_CAP = 75;
+const BASE_DEADLY_STRIKE_CHANCE_CAP = 75;
+const BASE_CRITICAL_STRIKE_MULTIPLIER = 2;
+const BASE_DEADLY_STRIKE_MULTIPLIER = 1.5;
+
+const EMPTY_STRIKE_MODIFIERS: DamageStrikeModifiers = {
+  criticalChance: 0,
+  deadlyStrikeChance: 0,
+  maxDeadlyStrikeChance: 0,
+  criticalMultiplierBonus: 0,
+  deadlyStrikeMultiplierBonus: 0,
+};
+
+const STRIKE_DAMAGE_SOURCE_REFS: DamageSourceReference[] = [
+  {
+    table: "Skills.txt / item stats",
+    columns: ["Critical / Deadly Strike"],
+  },
+];
 
 const GAME_TABLE_DEFINITIONS: Record<GameTableName, GameTableDefinition> = {
   Skills: { fileName: "Skills.txt", keyColumn: "skill", required: true },
@@ -2942,21 +2971,24 @@ function hasDamageRange(damage?: {
 }
 
 function getDamageFromArmoryItemData(
-  item: IItem
+  item: IItem,
+  damageKind: "kick" | "smite"
 ): DamageRangeWithSource | undefined {
-  const itemWithPossibleKickDamage = item as IItem & {
+  const itemWithArmorAttackDamage = item as IItem & {
     damage?: IItem["damage"] & {
       kick?: { minimum?: number; maximum?: number };
+      smite?: { minimum?: number; maximum?: number };
     };
     base?: IItem["base"] & {
       damage?: IItem["damage"] & {
         kick?: { minimum?: number; maximum?: number };
+        smite?: { minimum?: number; maximum?: number };
       };
     };
   };
   const damageCandidates = [
-    itemWithPossibleKickDamage.base?.damage?.kick,
-    itemWithPossibleKickDamage.damage?.kick,
+    itemWithArmorAttackDamage.base?.damage?.[damageKind],
+    itemWithArmorAttackDamage.damage?.[damageKind],
   ];
   const damage = damageCandidates.find(hasDamageRange);
   if (!damage) {
@@ -2969,15 +3001,25 @@ function getDamageFromArmoryItemData(
       {
         table: "Armory item data",
         row: item.base?.name || item.name,
-        columns: ["base.damage.kick", "damage.kick"],
-        note: "Equipped boot kick damage enriched from Armor.txt mindam/maxdam.",
+        columns: [
+          `base.damage.${damageKind}`,
+          `damage.${damageKind}`,
+        ],
+        note:
+          damageKind === "kick"
+            ? "Equipped boot kick damage enriched from Armor.txt mindam/maxdam."
+            : "Equipped shield Smite damage enriched from Armor.txt mindam/maxdam.",
       },
     ],
   };
 }
 
 function getBootKickDamage(item: IItem): DamageRangeWithSource | undefined {
-  return getDamageFromArmoryItemData(item);
+  return getDamageFromArmoryItemData(item, "kick");
+}
+
+function getShieldSmiteDamage(item: IItem): DamageRangeWithSource | undefined {
+  return getDamageFromArmoryItemData(item, "smite");
 }
 
 function isEquippedBootItem(item: IItem): boolean {
@@ -2991,6 +3033,23 @@ function isEquippedBootItem(item: IItem): boolean {
   const typeCode = item.base?.type_code?.toLowerCase();
   const typeName = item.base?.type?.toLowerCase() || "";
   return typeCode === "boot" || typeName.includes("boot");
+}
+
+function isEquippedShieldItem(item: IItem): boolean {
+  if (
+    item.location?.zone !== "Equipped" ||
+    !item.location?.equipment?.includes("Left Hand")
+  ) {
+    return false;
+  }
+
+  const typeCode = item.base?.type_code?.toLowerCase();
+  const typeName = item.base?.type?.toLowerCase() || "";
+  return (
+    typeCode === "shie" ||
+    typeCode === "ashd" ||
+    typeName.includes("shield")
+  );
 }
 
 function createUnarmedItem(weaponSet: WeaponSet): IItem {
@@ -3095,6 +3154,35 @@ function createKickSelection(
     slot: "feet",
     damageSourceRefs: kickDamage?.sourceRefs,
     baseDamageUnavailable: !kickDamage,
+  };
+}
+
+function createSmiteSelection(
+  weaponSet: WeaponSet,
+  item: IItem
+): WeaponSelection {
+  const setLabel = weaponSet === "primary" ? "Primary" : "Secondary";
+  const key = item.hash || String(item.id);
+  const baseName = item.base?.name || item.name;
+  const smiteDamage = getShieldSmiteDamage(item);
+
+  return {
+    option: {
+      id: `${weaponSet}:left:smite:${key}`,
+      label: `${setLabel} shield (Smite)`,
+      weaponSet,
+      slot: "left",
+      handMode: "smite",
+      itemName: item.name,
+      baseName,
+      weaponType: item.base?.type || "Shield",
+    },
+    item,
+    damage: smiteDamage?.damage || createEmptyDamageRange(),
+    weaponSet,
+    slot: "left",
+    damageSourceRefs: smiteDamage?.sourceRefs,
+    baseDamageUnavailable: !smiteDamage,
   };
 }
 
@@ -3357,6 +3445,11 @@ function getWeaponOptions(characterData: CharacterData): WeaponSelection[] {
     if (equippedBoots) {
       selections.push(createKickSelection(weaponSet, equippedBoots));
     }
+
+    const equippedShield = items.find(isEquippedShieldItem);
+    if (equippedShield) {
+      selections.push(createSmiteSelection(weaponSet, equippedShield));
+    }
   });
 
   const summonSkillNames = Array.from(getSkillMap(characterData).entries())
@@ -3420,7 +3513,10 @@ function getStatBonusPercent(
   strength: number,
   dexterity: number
 ): number {
-  if (weaponSelection.option.handMode === "kick") {
+  if (
+    weaponSelection.option.handMode === "kick" ||
+    weaponSelection.option.handMode === "smite"
+  ) {
     return (
       getPayloadStatBonusPercent(weaponSelection.item, strength, dexterity) ??
       strength
@@ -3740,6 +3836,7 @@ function isSelectableSpellSkill(skillName: string): boolean {
       Boolean(getGameRow("Skills", candidate))
     ) || skillName;
   if (
+    resolvedSkillName === "Holy Shield" ||
     isPlayerAuraSkill(resolvedSkillName) ||
     isGameSummonSkill(resolvedSkillName) ||
     isGameSelfOrPartyBuffSkill(resolvedSkillName)
@@ -4138,7 +4235,7 @@ function createDamageComponent(component: {
   id: string;
   label: string;
   source: DamageComponent["source"];
-  damageType: DamageElement;
+  damageType: DamageComponent["damageType"];
   timing?: DamageComponent["timing"];
   damage: DamageRange;
   baseDamage?: DamageRange;
@@ -4196,7 +4293,7 @@ function buildDamageTotals(
   const includedComponents = components.filter(
     (component) => component.includedInTotal !== false
   );
-  const byElement: Partial<Record<DamageElement, DamageRange>> = {};
+  const byElement: DamageTotals["byElement"] = {};
   let poisonDamage: PoisonDamage | undefined;
 
   includedComponents.forEach((component) => {
@@ -4239,6 +4336,153 @@ function buildDamageTotals(
     byElement,
     poisonDamage,
   };
+}
+
+function roundStrikeValue(value: number): number {
+  return Number(value.toFixed(3));
+}
+
+function addStrikeModifiers(
+  current: DamageStrikeModifiers,
+  addition: Partial<DamageStrikeModifiers>
+): DamageStrikeModifiers {
+  return {
+    criticalChance: current.criticalChance + (addition.criticalChance || 0),
+    deadlyStrikeChance:
+      current.deadlyStrikeChance + (addition.deadlyStrikeChance || 0),
+    maxDeadlyStrikeChance:
+      current.maxDeadlyStrikeChance + (addition.maxDeadlyStrikeChance || 0),
+    criticalMultiplierBonus:
+      current.criticalMultiplierBonus + (addition.criticalMultiplierBonus || 0),
+    deadlyStrikeMultiplierBonus:
+      current.deadlyStrikeMultiplierBonus +
+      (addition.deadlyStrikeMultiplierBonus || 0),
+  };
+}
+
+function buildStrikeBreakdown(
+  id: string,
+  label: string,
+  physicalComponentIds: string[],
+  modifiers: DamageStrikeModifiers
+): DamageStrikeBreakdown {
+  const rawCriticalChance = Math.max(0, modifiers.criticalChance);
+  const criticalChance = Math.min(
+    BASE_CRITICAL_STRIKE_CHANCE_CAP,
+    rawCriticalChance
+  );
+  const rawMaxDeadlyStrikeChance = Math.max(
+    0,
+    BASE_DEADLY_STRIKE_CHANCE_CAP + modifiers.maxDeadlyStrikeChance
+  );
+  const maxDeadlyStrikeChance = Math.min(100, rawMaxDeadlyStrikeChance);
+  const rawDeadlyStrikeChance = Math.max(0, modifiers.deadlyStrikeChance);
+  const deadlyStrikeChance = Math.min(
+    maxDeadlyStrikeChance,
+    rawDeadlyStrikeChance
+  );
+  const effectiveDeadlyStrikeChance =
+    deadlyStrikeChance * (1 - criticalChance / 100);
+
+  return {
+    id,
+    label,
+    physicalComponentIds,
+    rawCriticalChance: roundStrikeValue(rawCriticalChance),
+    criticalChance: roundStrikeValue(criticalChance),
+    criticalMultiplier: roundStrikeValue(
+      Math.max(
+        1,
+        BASE_CRITICAL_STRIKE_MULTIPLIER +
+          modifiers.criticalMultiplierBonus / 100
+      )
+    ),
+    rawDeadlyStrikeChance: roundStrikeValue(rawDeadlyStrikeChance),
+    rawMaxDeadlyStrikeChance: roundStrikeValue(rawMaxDeadlyStrikeChance),
+    deadlyStrikeChance: roundStrikeValue(deadlyStrikeChance),
+    maxDeadlyStrikeChance: roundStrikeValue(maxDeadlyStrikeChance),
+    effectiveDeadlyStrikeChance: roundStrikeValue(effectiveDeadlyStrikeChance),
+    deadlyStrikeMultiplier: roundStrikeValue(
+      Math.max(
+        1,
+        BASE_DEADLY_STRIKE_MULTIPLIER +
+          modifiers.deadlyStrikeMultiplierBonus / 100
+      )
+    ),
+  };
+}
+
+function createStrikeDamageComponents(
+  components: readonly DamageComponent[],
+  strikeBreakdowns: readonly DamageStrikeBreakdown[]
+): DamageComponent[] {
+  const componentsById = new Map(
+    components.map((component) => [component.id, component])
+  );
+
+  return strikeBreakdowns.flatMap((strike) => {
+    const physicalDamage = strike.physicalComponentIds.reduce(
+      (total, componentId) => {
+        const component = componentsById.get(componentId);
+        return component &&
+          component.damageType === "physical" &&
+          component.timing === "instant"
+          ? addDamageRange(total, component.damage)
+          : total;
+      },
+      createEmptyDamageRange()
+    );
+    if (!isNonZeroDamageRange(physicalDamage)) {
+      return [];
+    }
+
+    const outcomes: Array<{
+      type: "critical" | "deadly";
+      label: string;
+      chance: number;
+      multiplier: number;
+    }> = [
+      {
+        type: "critical",
+        label: "Critical Strike bonus",
+        chance: strike.criticalChance,
+        multiplier: strike.criticalMultiplier,
+      },
+      {
+        type: "deadly",
+        label: "Deadly Strike bonus",
+        chance: strike.effectiveDeadlyStrikeChance,
+        multiplier: strike.deadlyStrikeMultiplier,
+      },
+    ];
+
+    return outcomes.flatMap((outcome) => {
+      const expectedMultiplier =
+        (outcome.chance / 100) * (outcome.multiplier - 1);
+      const damage = {
+        min: physicalDamage.min * expectedMultiplier,
+        max: physicalDamage.max * expectedMultiplier,
+      };
+      if (!isNonZeroDamageRange(damage)) {
+        return [];
+      }
+
+      return [
+        createDamageComponent({
+          id: `strike:${strike.id}:${outcome.type}`,
+          label:
+            strike.label === "Attack"
+              ? outcome.label
+              : `${strike.label}: ${outcome.label}`,
+          source: "stat",
+          damageType: outcome.type,
+          damage,
+          sourceRefs: STRIKE_DAMAGE_SOURCE_REFS,
+          notes: [],
+        }),
+      ];
+    });
+  });
 }
 
 function elementalDamageFromTotals(
@@ -5451,6 +5695,245 @@ function getPassiveSkillDamagePercent(
   return total;
 }
 
+function parseRenderedStrikeModifier(
+  properties: IItem["properties"],
+  kind: keyof DamageStrikeModifiers
+): number {
+  const patterns: Record<keyof DamageStrikeModifiers, RegExp[]> = {
+    criticalChance: [
+      /^(?:\+)?([\d.]+)% (?:Chance of )?Critical Strike$/i,
+      /^Critical Strike Chance(?: \+)?([\d.]+)%$/i,
+    ],
+    deadlyStrikeChance: [
+      /^(?:\+)?([\d.]+)% (?:Chance of )?Deadly Strike$/i,
+      /^Deadly Strike Chance(?: \+)?([\d.]+)%$/i,
+    ],
+    maxDeadlyStrikeChance: [
+      /^(?:\+)?([\d.]+)% (?:to )?Maximum Deadly Strike$/i,
+      /^Maximum Deadly Strike(?: \+)?([\d.]+)%$/i,
+    ],
+    criticalMultiplierBonus: [
+      /^(?:\+)?([\d.]+)% Critical Strike Multiplier$/i,
+      /^Critical Strike Multiplier(?: \+)?([\d.]+)%$/i,
+    ],
+    deadlyStrikeMultiplierBonus: [
+      /^(?:\+)?([\d.]+)% Deadly Strike Multiplier$/i,
+      /^Deadly Strike Multiplier(?: \+)?([\d.]+)%$/i,
+    ],
+  };
+
+  return properties.reduce((total, property) => {
+    if (!property) {
+      return total;
+    }
+
+    const match = patterns[kind]
+      .map((pattern) => property.match(pattern))
+      .find(Boolean);
+    return total + (match ? Number(match[1]) : 0);
+  }, 0);
+}
+
+function parseRenderedDeadlyStrikePerLevel(
+  properties: IItem["properties"]
+): number {
+  return properties.reduce((total, property) => {
+    const match = property?.match(
+      /^(?:\+)?([\d.]+)% (?:Chance of )?Deadly Strike \(Based on Character Level\)$/i
+    );
+    return total + (match ? Number(match[1]) : 0);
+  }, 0);
+}
+
+function getItemStrikeModifiers(
+  playerItems: IItem[],
+  selectedWeapon: WeaponSelection,
+  characterLevel: number
+): DamageStrikeModifiers {
+  const selectedWeaponKey =
+    selectedWeapon.item.hash || String(selectedWeapon.item.id);
+
+  return playerItems.reduce<DamageStrikeModifiers>(
+    (total, item) => {
+      const itemKey = item.hash || String(item.id);
+      const isWeapon = item.category === "weapon";
+      const isSelectedWeapon = itemKey === selectedWeaponKey;
+      if (
+        (!isSelectedWeapon &&
+          !isEquippedItem(item) &&
+          !isActiveInventoryCharm(item)) ||
+        (isWeapon && !isSelectedWeapon)
+      ) {
+        return total;
+      }
+
+      const ledger = expandItemStats(item);
+      const rawPerLevelDeadlyStrike = ledger.item_deadlystrike_perlevel || 0;
+      const perLevelDeadlyStrike = Math.floor(
+        (rawPerLevelDeadlyStrike ||
+          parseRenderedDeadlyStrikePerLevel(item.properties)) * characterLevel
+      );
+      const rawModifiers: DamageStrikeModifiers = {
+        criticalChance: ledger.item_crit_chance || 0,
+        deadlyStrikeChance: ledger.item_deadlystrike || 0,
+        maxDeadlyStrikeChance: ledger.item_maxdeadlystrike || 0,
+        criticalMultiplierBonus: ledger.item_crit_multiplier || 0,
+        deadlyStrikeMultiplierBonus: ledger.item_ds_multiplier || 0,
+      };
+
+      return addStrikeModifiers(total, {
+        criticalChance:
+          rawModifiers.criticalChance ||
+          parseRenderedStrikeModifier(item.properties, "criticalChance"),
+        deadlyStrikeChance:
+          (rawModifiers.deadlyStrikeChance ||
+            parseRenderedStrikeModifier(
+              item.properties,
+              "deadlyStrikeChance"
+            )) + perLevelDeadlyStrike,
+        maxDeadlyStrikeChance:
+          rawModifiers.maxDeadlyStrikeChance ||
+          parseRenderedStrikeModifier(item.properties, "maxDeadlyStrikeChance"),
+        criticalMultiplierBonus:
+          rawModifiers.criticalMultiplierBonus ||
+          parseRenderedStrikeModifier(
+            item.properties,
+            "criticalMultiplierBonus"
+          ),
+        deadlyStrikeMultiplierBonus:
+          rawModifiers.deadlyStrikeMultiplierBonus ||
+          parseRenderedStrikeModifier(
+            item.properties,
+            "deadlyStrikeMultiplierBonus"
+          ),
+      });
+    },
+    { ...EMPTY_STRIKE_MODIFIERS }
+  );
+}
+
+function passiveStrikeSkillAppliesToWeapon(
+  skillName: string,
+  skillRow: string[],
+  weaponSelection: WeaponSelection
+): boolean {
+  const restrictedTypes = SKILL_WEAPON_TYPE_COLUMN_PREFIXES.flatMap((prefix) =>
+    getSkillWeaponTypeCodes(skillRow, prefix)
+  );
+  if (restrictedTypes.length > 0) {
+    return weaponSelectionMatchesAnySkillWeaponType(
+      weaponSelection,
+      restrictedTypes
+    );
+  }
+
+  const itemTypes = getItemWeaponTypeCodes(weaponSelection.item);
+  switch (getGameRowString("Skills", skillRow, "skill") || skillName) {
+    case "Sword Mastery":
+      return itemTypes.has("swor");
+    case "One Hand Mastery":
+      return weaponSelection.option.handMode === "one_handed";
+    case "Mace Mastery":
+      return itemTypes.has("blun");
+    case "Throwing Mastery":
+      return (
+        weaponSelection.option.handMode === "missile" &&
+        !isBowOrCrossbow(weaponSelection.item)
+      );
+    case "Spear Mastery":
+      return itemTypes.has("spea") || itemTypes.has("pole");
+    default:
+      return true;
+  }
+}
+
+function getPassiveStrikeModifiers(
+  weaponSelection: WeaponSelection,
+  skillMap: Map<string, SkillEntry>
+): DamageStrikeModifiers {
+  let modifiers = { ...EMPTY_STRIKE_MODIFIERS };
+  const processedSkillRows = new Set<string>();
+
+  skillMap.forEach((entry, skillName) => {
+    const skillRow = getGameRow("Skills", skillName);
+    const sourceSkillName = skillRow
+      ? getGameRowString("Skills", skillRow, "skill") || skillName
+      : skillName;
+    const appliesToWeapon = skillRow
+      ? passiveStrikeSkillAppliesToWeapon(
+          skillName,
+          skillRow,
+          weaponSelection
+        )
+      : false;
+    const hasGlobalCriticalMultiplier =
+      sourceSkillName === "Javelin and Spear Mastery";
+    if (
+      entry.level <= 0 ||
+      !skillRow ||
+      processedSkillRows.has(sourceSkillName.toLowerCase()) ||
+      (!appliesToWeapon && !hasGlobalCriticalMultiplier)
+    ) {
+      return;
+    }
+    processedSkillRows.add(sourceSkillName.toLowerCase());
+
+    modifiers = addStrikeModifiers(modifiers, {
+      criticalChance: appliesToWeapon
+        ? getGameSkillPassiveStatValue(
+            skillName,
+            [
+              "passive_critical_strike",
+              "passive_mastery_melee_crit",
+              "passive_mastery_throw_crit",
+              "item_crit_chance",
+            ],
+            skillMap
+          ) || 0
+        : 0,
+      // S13 currently applies this new multiplier to every weapon even though
+      // the mastery damage columns in Skills.txt remain spear-restricted.
+      criticalMultiplierBonus:
+        appliesToWeapon || hasGlobalCriticalMultiplier
+          ? getGameSkillPassiveStatValue(
+              skillName,
+              ["item_crit_multiplier"],
+              skillMap
+            ) || 0
+          : 0,
+    });
+  });
+
+  return modifiers;
+}
+
+function getSelectedSkillStrikeModifiers(
+  selectedSkillName: string,
+  selectedSkillLevel: number,
+  skillMap: Map<string, SkillEntry>
+): DamageStrikeModifiers {
+  if (selectedSkillName !== "Joust") {
+    return { ...EMPTY_STRIKE_MODIFIERS };
+  }
+
+  const skillRow = getGameRow("Skills", selectedSkillName);
+  return {
+    ...EMPTY_STRIKE_MODIFIERS,
+    criticalChance: skillRow
+      ? evaluateGameCalcExpression(
+          getGameRowString("Skills", skillRow, "calc2"),
+          skillRow,
+          skillMap,
+          selectedSkillLevel
+        )
+      : 0,
+  };
+}
+
+function skillCanApplyStrikeDamage(selectedSkillName: string): boolean {
+  return selectedSkillName !== "Sacrifice" && selectedSkillName !== "Smite";
+}
+
 function parseItemDamageStats(
   playerItems: IItem[],
   selectedWeapon: WeaponSelection
@@ -5674,6 +6157,42 @@ function parseItemDamageStats(
   };
 }
 
+function getSmiteItemNormalDamage(
+  playerItems: IItem[]
+): DamageRangeWithSource | undefined {
+  const sourceWeapon = playerItems.find(
+    (item) =>
+      item.location?.zone === "Equipped" &&
+      getLogicalHandSlot(item.location?.equipment) === "right" &&
+      item.category === "weapon"
+  );
+  if (!sourceWeapon) {
+    return undefined;
+  }
+
+  const ledgerDamage = expandItemStats(sourceWeapon).item_normaldamage || 0;
+  const renderedDamage = sourceWeapon.properties.reduce((total, property) => {
+    const match = property?.match(/^Damage \+(\d+)$/i);
+    return total + (match ? Number(match[1]) : 0);
+  }, 0);
+  const damage = ledgerDamage || renderedDamage;
+  if (damage <= 0) {
+    return undefined;
+  }
+
+  return {
+    damage: { min: damage, max: damage },
+    sourceRefs: [
+      {
+        table: "ItemStatCost.txt / Armory item modifiers",
+        row: sourceWeapon.name,
+        columns: ["item_normaldamage"],
+        note: "The Damage +X stat on the equipped weapon is added to Smite base damage; ordinary weapon and item min/max damage are excluded.",
+      },
+    ],
+  };
+}
+
 function getAuraFormulaSkillName(auraName: string): string {
   return getPlayerAuraDefinition(auraName)?.skillName || auraName;
 }
@@ -5806,6 +6325,35 @@ function getAuraSkillLevelBonus(aura: AuraSource): number {
       : gamePartyValue;
 
   return gameValue ?? 0;
+}
+
+function getAuraStrikeStatValue(aura: AuraSource, statName: string): number {
+  const skillMap = new Map<string, SkillEntry>();
+  const selfValue =
+    aura.carrier === "self"
+      ? getGameAuraStatValue(aura, [statName], "self", skillMap)
+      : undefined;
+  const partyValue = getGameAuraStatValue(aura, [statName], "party", skillMap);
+
+  return (
+    (aura.carrier === "self" ? (selfValue ?? partyValue) : partyValue) || 0
+  );
+}
+
+function getAuraStrikeModifiers(aura: AuraSource): DamageStrikeModifiers {
+  return {
+    criticalChance: getAuraStrikeStatValue(aura, "item_crit_chance"),
+    deadlyStrikeChance: getAuraStrikeStatValue(aura, "item_deadlystrike"),
+    maxDeadlyStrikeChance: getAuraStrikeStatValue(aura, "item_maxdeadlystrike"),
+    criticalMultiplierBonus: getAuraStrikeStatValue(
+      aura,
+      "item_crit_multiplier"
+    ),
+    deadlyStrikeMultiplierBonus: getAuraStrikeStatValue(
+      aura,
+      "item_ds_multiplier"
+    ),
+  };
 }
 
 function getTotalAuraSkillLevelBonus(activeAuras: AuraSource[]): number {
@@ -6163,6 +6711,7 @@ function getManualAuraLevelBonus(
     physicalBonusPercent: getAuraPhysicalDamagePercent(aura),
     elementalDamage: getAuraAttackDamage(aura, new Map()),
     poisonDamage: getAuraPoisonDamage(aura, new Map()),
+    strikeModifiers: getAuraStrikeModifiers(aura),
   };
 }
 
@@ -6361,7 +6910,7 @@ function isSkillWeaponTypeHandModeCompatible(
         weaponSelection.option.handMode !== "unarmed"
       );
     case "shld":
-      return false;
+      return weaponSelection.option.handMode === "smite";
     default:
       return undefined;
   }
@@ -6479,6 +7028,15 @@ function isWeaponSelectionCompatibleWithSkill(
   }
 
   if (weaponSelection.option.handMode === "summon") {
+    return false;
+  }
+
+  const isSmiteSkill = sourceSkillName === "Smite";
+  if (isSmiteSkill) {
+    return weaponSelection.option.handMode === "smite";
+  }
+
+  if (weaponSelection.option.handMode === "smite") {
     return false;
   }
 
@@ -6780,6 +7338,7 @@ function buildSummonProfile(
     activeAuras: activeAuras.map(summarizeAuraSource),
     damageScope,
     damageComponents,
+    strikeBreakdowns: [],
     damageTotals,
     ...getAuraPulseProfileFields(auraPulseDamageComponents),
     totalPhysicalDamage,
@@ -6905,6 +7464,7 @@ function buildSpellProfile(
     activeAuras: activeAuras.map(summarizeAuraSource),
     damageScope,
     damageComponents,
+    strikeBreakdowns: [],
     damageTotals,
     ...getAuraPulseProfileFields(auraPulseDamageComponents),
     totalPhysicalDamage,
@@ -6955,6 +7515,16 @@ function buildSequenceProfile(
       ...component,
       id: `sequence:${index + 1}:${component.id}`,
       label: `${hit.label}: ${component.label}`,
+    }))
+  );
+  const strikeBreakdowns = hitProfiles.flatMap(({ hit, profile }, index) =>
+    profile.strikeBreakdowns.map((strike) => ({
+      ...strike,
+      id: `sequence:${index + 1}:${strike.id}`,
+      label: `${hit.label}: ${strike.label}`,
+      physicalComponentIds: strike.physicalComponentIds.map(
+        (componentId) => `sequence:${index + 1}:${componentId}`
+      ),
     }))
   );
   const auraPulseDamageComponents = hitProfiles.flatMap(
@@ -7019,6 +7589,7 @@ function buildSequenceProfile(
     activeAuras: firstProfile?.activeAuras ?? [],
     damageScope,
     damageComponents,
+    strikeBreakdowns,
     damageTotals,
     ...getAuraPulseProfileFields(auraPulseDamageComponents),
     totalPhysicalDamage,
@@ -7095,6 +7666,7 @@ function buildProfile(
   const characterClass = characterData.character.class.name;
   const displaySkillName = skillOption.name;
   const selectedSkillName = skillOption.sourceSkillName || skillOption.name;
+  const isSmiteProfile = selectedSkillName === "Smite";
 
   const selectedPlayerAura =
     playerAuraOption.id === "none"
@@ -7124,6 +7696,12 @@ function buildProfile(
         skillOption.level;
 
   const parsedItemDamage = parseItemDamageStats(playerItems, weaponSelection);
+  const smiteItemNormalDamage = isSmiteProfile
+    ? getSmiteItemNormalDamage(playerItems)
+    : undefined;
+  const flatPhysicalDamage = isSmiteProfile
+    ? smiteItemNormalDamage?.damage || createEmptyDamageRange()
+    : parsedItemDamage.flatPhysicalDamage;
   const statBonusPercent = getStatBonusPercent(
     characterClass,
     weaponSelection,
@@ -7190,6 +7768,32 @@ function buildProfile(
           selectedSkillName,
           directSkillDamageToComponents(selectedSkillName, directDamage)
         );
+  const holyShieldLevel = isSmiteProfile
+    ? getSkillEntry(effectiveSkillMap, "Holy Shield").level
+    : 0;
+  const holyShieldDamageComponents =
+    holyShieldLevel > 0
+      ? directSkillDamageToComponents(
+          "Holy Shield",
+          getDirectSkillDamage(
+            "Holy Shield",
+            holyShieldLevel,
+            effectiveSkillMap,
+            realStats
+          )
+        )
+          .filter((component) => component.damageType === "physical")
+          .map((component) => ({
+            ...component,
+            label: "Holy Shield bonus",
+          }))
+      : [];
+  const physicalSkillDamageComponents = [
+    ...directDamageComponents.filter(
+      (component) => component.damageType === "physical"
+    ),
+    ...holyShieldDamageComponents,
+  ];
   const selectedSkillRow =
     selectedSkillName === "Basic Attack"
       ? undefined
@@ -7203,10 +7807,13 @@ function buildProfile(
     max: Math.floor(weaponSelection.damage.max * weaponSourceModifier),
   };
   const usesKickSource = weaponSelection.option.handMode === "kick";
+  const usesShieldSource = weaponSelection.option.handMode === "smite";
   const weaponSourceLabel = usesKickSource
     ? selectedSkillName === "Basic Attack"
       ? "Boot source"
       : `Boot source (${displaySkillName})`
+    : usesShieldSource
+      ? `Shield source (${displaySkillName})`
     : selectedSkillName === "Basic Attack"
       ? "Weapon source"
       : `Weapon source (${displaySkillName})`;
@@ -7218,27 +7825,66 @@ function buildProfile(
           {
             table: "Character equipment",
             row: weaponSelection.item.name,
-            columns: [usesKickSource ? "boot kick damage" : "weapon damage"],
+            columns: [
+              usesKickSource
+                ? "boot kick damage"
+                : usesShieldSource
+                  ? "shield Smite damage"
+                  : "weapon damage",
+            ],
           },
         ];
   const selectedSkillSourceNote = usesKickSource
     ? "Kick=1 marks this as a boot-sourced kick attack in the game-file skill row."
+    : usesShieldSource
+      ? "itypea1=shld and weapsel=4 mark Smite as a shield-sourced attack in the game-file skill row."
     : weaponSourceSrcDam > 0
       ? `SrcDam=${weaponSourceSrcDam} is the game-file source-damage scalar; the extracted files expose the raw value but not the engine denominator.`
       : "Source-damage and attack-signal fields are preserved from game files; opaque engine function behavior is not inferred.";
   const flatAndSkillPhysicalDamage = addDamageRange(
-    parsedItemDamage.flatPhysicalDamage,
-    directDamageComponents
-      .filter((component) => component.damageType === "physical")
-      .reduce(
-        (total, component) => addDamageRange(total, component.damage),
-        createEmptyDamageRange()
-      )
+    flatPhysicalDamage,
+    physicalSkillDamageComponents.reduce(
+      (total, component) => addDamageRange(total, component.damage),
+      createEmptyDamageRange()
+    )
   );
   const physicalMultiplier = 1 + totalPhysicalBonusPercent / 100;
   const physicalBaseComponents: DamageComponent[] = [];
 
-  if (isNonZeroDamageRange(carriedWeaponDamage)) {
+  if (isSmiteProfile) {
+    const smiteBaseDamage = addDamageRange(
+      carriedWeaponDamage,
+      flatAndSkillPhysicalDamage
+    );
+    if (isNonZeroDamageRange(smiteBaseDamage)) {
+      physicalBaseComponents.push(
+        createDamageComponent({
+          id: `smite-base:${weaponSelection.option.id}`,
+          label: "Smite physical base",
+          source: "weapon",
+          damageType: "physical",
+          damage: smiteBaseDamage,
+          baseDamage: smiteBaseDamage,
+          sourceRefs: [
+            ...equipmentDamageSourceRefs,
+            {
+              table: "Skills.txt",
+              row: "Smite",
+              columns: ["itypea1", "weapsel", "calc1"],
+              note: selectedSkillSourceNote,
+            },
+            ...holyShieldDamageComponents.flatMap(
+              (component) => component.sourceRefs
+            ),
+            ...(smiteItemNormalDamage?.sourceRefs || []),
+          ],
+          notes: [
+            "Smite base damage is the equipped shield range plus active Holy Shield damage and applicable weapon Damage +X before physical percentage bonuses.",
+          ],
+        })
+      );
+    }
+  } else if (isNonZeroDamageRange(carriedWeaponDamage)) {
     physicalBaseComponents.push(
       createDamageComponent({
         id: `weapon:${weaponSelection.option.id}:${selectedSkillName}`,
@@ -7266,15 +7912,15 @@ function buildProfile(
     );
   }
 
-  if (isNonZeroDamageRange(parsedItemDamage.flatPhysicalDamage)) {
+  if (!isSmiteProfile && isNonZeroDamageRange(flatPhysicalDamage)) {
     physicalBaseComponents.push(
       createDamageComponent({
         id: `item-flat-physical:${weaponSelection.option.id}`,
         label: "Item flat physical",
         source: "item",
         damageType: "physical",
-        damage: parsedItemDamage.flatPhysicalDamage,
-        baseDamage: parsedItemDamage.flatPhysicalDamage,
+        damage: flatPhysicalDamage,
+        baseDamage: flatPhysicalDamage,
         sourceRefs: [
           {
             table: "Armory item text",
@@ -7285,21 +7931,62 @@ function buildProfile(
     );
   }
 
-  directDamageComponents
-    .filter((component) => component.damageType === "physical")
-    .forEach((component) => {
+  if (!isSmiteProfile) {
+    physicalSkillDamageComponents.forEach((component) => {
       physicalBaseComponents.push({
         ...component,
         baseDamage: component.damage,
       });
     });
+  }
 
   const physicalComponents = physicalBaseComponents.map((component) =>
     scalePhysicalDamageComponent(component, physicalMultiplier)
   );
+  let strikeModifiers = getItemStrikeModifiers(
+    playerItems,
+    weaponSelection,
+    characterData.character.level
+  );
+  strikeModifiers = addStrikeModifiers(
+    strikeModifiers,
+    getPassiveStrikeModifiers(weaponSelection, effectiveSkillMap)
+  );
+  strikeModifiers = addStrikeModifiers(
+    strikeModifiers,
+    getSelectedSkillStrikeModifiers(
+      selectedSkillName,
+      selectedSkillLevel,
+      effectiveSkillMap
+    )
+  );
+  activeAuras.forEach((aura) => {
+    strikeModifiers = addStrikeModifiers(
+      strikeModifiers,
+      getAuraStrikeModifiers(aura)
+    );
+  });
+  const strikeBreakdowns = skillCanApplyStrikeDamage(selectedSkillName)
+    ? [
+        buildStrikeBreakdown(
+          `attack:${weaponSelection.option.id}:${selectedSkillName}`,
+          "Attack",
+          physicalComponents.map((component) => component.id),
+          strikeModifiers
+        ),
+      ]
+    : [];
+  const strikeComponents = createStrikeDamageComponents(
+    physicalComponents,
+    strikeBreakdowns
+  );
 
   const itemElementalComponents: DamageComponent[] = [];
   (["fire", "cold", "lightning", "magic"] as const).forEach((element) => {
+    if (isSmiteProfile) {
+      return;
+    }
+
     if (
       isVengeanceSkill(selectedSkillName) &&
       (element === "fire" || element === "cold" || element === "lightning")
@@ -7367,7 +8054,7 @@ function buildProfile(
           );
 
   const auraElementalComponents: DamageComponent[] = [];
-  activeAuras.forEach((aura) => {
+  (isSmiteProfile ? [] : activeAuras).forEach((aura) => {
     const addition = getAuraAttackDamage(aura, effectiveSkillMap, realStats);
     (["fire", "cold", "lightning", "magic"] as const).forEach((element) => {
       const damage = addition[element];
@@ -7413,7 +8100,8 @@ function buildProfile(
     }
   });
 
-  const itemPoisonComponents = parsedItemDamage.poisonDamage
+  const itemPoisonComponents =
+    !isSmiteProfile && parsedItemDamage.poisonDamage
     ? [
         createDamageComponent({
           id: `item-poison:${weaponSelection.option.id}`,
@@ -7442,6 +8130,7 @@ function buildProfile(
 
   const damageComponents = [
     ...physicalComponents,
+    ...strikeComponents,
     ...itemElementalComponents,
     ...skillPayloadComponents,
     ...weaponElementalDamageComponents,
@@ -7497,6 +8186,24 @@ function buildProfile(
     );
   }
 
+  if (usesShieldSource && weaponSelection.baseDamageUnavailable) {
+    notes.push(
+      "This Smite profile uses the equipped shield as its attack source, but shield base Smite damage is unavailable because Armor.txt is not present in the current extract and the armory payload does not expose shield damage."
+    );
+  }
+
+  if (isSmiteProfile && holyShieldLevel > 0) {
+    notes.push(
+      `Holy Shield level ${holyShieldLevel} damage is added to the shield base before Smite multipliers; Skills.txt applies its (Smite base level + Defiance base level) × Param7 synergy formula.`
+    );
+  }
+
+  if (!skillCanApplyStrikeDamage(selectedSkillName)) {
+    notes.push(
+      `${displaySkillName} does not benefit from Critical Strike or Deadly Strike in Project Diablo 2, so strike bonus damage is excluded.`
+    );
+  }
+
   return {
     key: `${weaponSelection.option.id}::${skillOption.id}${getSkillProfileKeySuffix(skillOption)}::${playerAuraOption.id}:${playerAuraOption.level}::${playerAuraCarrier}`,
     weaponId: weaponSelection.option.id,
@@ -7524,6 +8231,7 @@ function buildProfile(
     activeAuras: activeAuras.map(summarizeAuraSource),
     damageScope: effectiveDamageScope,
     damageComponents,
+    strikeBreakdowns,
     damageTotals,
     ...getAuraPulseProfileFields(auraPulseDamageComponents),
     totalPhysicalDamage,
@@ -7682,7 +8390,8 @@ export function calculateDamage(
   );
 
   const notes = [
-    "Damage is an estimate built from PD2 game files. Totals combine immediate hit damage with modeled damage-over-time totals, but they do not include attack speed, cast speed, hit chance, target resistances, crushing blow, deadly strike, critical strike, repeated summon attacks, or conditional buffs.",
+    "Damage is an estimate built from PD2 game files. Totals combine immediate hit damage, expected Critical/Deadly Strike bonus damage, and modeled damage-over-time totals, but they do not include attack speed, cast speed, hit chance, target resistances, crushing blow, repeated summon attacks, or conditional buffs.",
+    "Critical Strike is capped at 75% and checked before Deadly Strike; Deadly Strike is capped at 75% plus Maximum Deadly Strike, up to 100%. Expected strike bonuses apply only to instant physical attack damage, and weapon strike stats apply only to hits with that weapon.",
   ];
 
   if (weaponSelections.some((selection) => selection.sequenceHits?.length)) {

--- a/api/src/utils/item-stat-expansion.test.ts
+++ b/api/src/utils/item-stat-expansion.test.ts
@@ -110,4 +110,12 @@ describe("item stat expansion", () => {
     expect(ranges.lightning).toEqual({ min: 10, max: 20 });
     expect(ranges.cold).toEqual({ min: 10, max: 20 });
   });
+
+  it("expands per-level Deadly Strike from the func 17 coefficient slot", () => {
+    const ledger = expandItemStats(
+      item([modifier("deadly/lvl", [0, 0, 0.25])])
+    );
+
+    expect(ledger.item_deadlystrike_perlevel).toBe(0.25);
+  });
 });

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -46,7 +46,8 @@
         "postcss-simple-vars": "7.0.1",
         "typescript": "5.6.2",
         "typescript-eslint": "8.11.0",
-        "vite": "5.4.11"
+        "vite": "5.4.11",
+        "vitest": "2.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2109,6 +2110,145 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.8",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@yaireo/relative-time": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@yaireo/relative-time/-/relative-time-1.0.5.tgz",
@@ -2181,6 +2321,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2258,6 +2408,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2299,6 +2459,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2314,6 +2491,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/clsx": {
@@ -2561,6 +2748,16 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2590,6 +2787,13 @@
       "integrity": "sha512-ov8rBoOBhVawpzdre+Cmz4FB+y66Eqrk6Gwqd8NGxuhv99GQ8XqMAr351KEkOt7gukXWDg6gJWEMKgL2RLMPtA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2822,6 +3026,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2837,6 +3051,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3281,6 +3505,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3289,6 +3520,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mantine-react-table": {
@@ -3486,6 +3727,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -4155,6 +4413,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4164,6 +4429,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -4226,6 +4505,50 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -4563,6 +4886,95 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.8",
+        "@vitest/mocker": "2.1.8",
+        "@vitest/pretty-format": "^2.1.8",
+        "@vitest/runner": "2.1.8",
+        "@vitest/snapshot": "2.1.8",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.8",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.8",
+        "@vitest/ui": "2.1.8",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4577,6 +4989,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -48,6 +49,7 @@
     "postcss-simple-vars": "7.0.1",
     "typescript": "5.6.2",
     "typescript-eslint": "8.11.0",
-    "vite": "5.4.11"
+    "vite": "5.4.11",
+    "vitest": "2.1.8"
   }
 }

--- a/web/src/components/character/DamageCalculatorSection.tsx
+++ b/web/src/components/character/DamageCalculatorSection.tsx
@@ -24,12 +24,15 @@ import type {
   DamageTransformationOption,
   DamageWeaponOption,
 } from "../../types";
+import {
+  applyStrikeModifierDelta,
+  rebuildStrikeDamageComponents,
+  rescalePhysicalComponents,
+} from "../../utils/damage-profile-adjustments";
 import { STAT_COLORS } from "./stat-colors";
 
 const SPELL_AURA_DAMAGE_NOTE =
   "Selected attack aura damage payloads are not applied to spell damage.";
-
-const BASE_CRITICAL_STRIKE_CHANCE_CAP = 75;
 
 const EMPTY_STRIKE_MODIFIERS: DamageAuraOption["levelBonuses"][number]["strikeModifiers"] =
   {
@@ -39,13 +42,6 @@ const EMPTY_STRIKE_MODIFIERS: DamageAuraOption["levelBonuses"][number]["strikeMo
     criticalMultiplierBonus: 0,
     deadlyStrikeMultiplierBonus: 0,
   };
-
-const STRIKE_DAMAGE_SOURCE_REFS = [
-  {
-    table: "Skills.txt / item stats",
-    columns: ["Critical / Deadly Strike"],
-  },
-];
 
 function formatNumber(value: number, round = false) {
   const numericValue = Number(value);
@@ -1136,179 +1132,6 @@ function normalizeDamageProfile(profile: DamageProfile): DamageProfile {
     ),
     notes: runtimeProfile.notes ?? [],
   };
-}
-
-function rescalePhysicalComponents(
-  components: DamageProfile["damageComponents"],
-  previousMultiplier: number,
-  nextMultiplier: number
-): DamageProfile["damageComponents"] {
-  return components.map((component) => {
-    if (component.damageType !== "physical" || component.timing !== "instant") {
-      return component;
-    }
-
-    const baseDamage = component.baseDamage || {
-      min:
-        previousMultiplier === 0
-          ? component.damage.min
-          : component.damage.min / previousMultiplier,
-      max:
-        previousMultiplier === 0
-          ? component.damage.max
-          : component.damage.max / previousMultiplier,
-    };
-
-    return {
-      ...component,
-      baseDamage,
-      damage: {
-        min: Math.floor(baseDamage.min * nextMultiplier),
-        max: Math.max(
-          Math.floor(baseDamage.min * nextMultiplier),
-          Math.floor(baseDamage.max * nextMultiplier)
-        ),
-      },
-    };
-  });
-}
-
-function roundStrikeValue(value: number) {
-  return Number(value.toFixed(3));
-}
-
-function applyStrikeModifierDelta(
-  strike: DamageProfile["strikeBreakdowns"][number],
-  next: DamageAuraOption["levelBonuses"][number]["strikeModifiers"],
-  previous: DamageAuraOption["levelBonuses"][number]["strikeModifiers"]
-): DamageProfile["strikeBreakdowns"][number] {
-  const rawCriticalChance = Math.max(
-    0,
-    strike.rawCriticalChance + next.criticalChance - previous.criticalChance
-  );
-  const criticalChance = Math.min(
-    BASE_CRITICAL_STRIKE_CHANCE_CAP,
-    rawCriticalChance
-  );
-  const rawMaxDeadlyStrikeChance = Math.max(
-    0,
-    strike.rawMaxDeadlyStrikeChance +
-      next.maxDeadlyStrikeChance -
-      previous.maxDeadlyStrikeChance
-  );
-  const maxDeadlyStrikeChance = Math.min(100, rawMaxDeadlyStrikeChance);
-  const rawDeadlyStrikeChance = Math.max(
-    0,
-    strike.rawDeadlyStrikeChance +
-      next.deadlyStrikeChance -
-      previous.deadlyStrikeChance
-  );
-  const deadlyStrikeChance = Math.min(
-    maxDeadlyStrikeChance,
-    rawDeadlyStrikeChance
-  );
-  const criticalMultiplier = Math.max(
-    1,
-    strike.criticalMultiplier +
-      (next.criticalMultiplierBonus - previous.criticalMultiplierBonus) / 100
-  );
-  const deadlyStrikeMultiplier = Math.max(
-    1,
-    strike.deadlyStrikeMultiplier +
-      (next.deadlyStrikeMultiplierBonus -
-        previous.deadlyStrikeMultiplierBonus) /
-        100
-  );
-
-  return {
-    ...strike,
-    rawCriticalChance: roundStrikeValue(rawCriticalChance),
-    criticalChance: roundStrikeValue(criticalChance),
-    criticalMultiplier: roundStrikeValue(criticalMultiplier),
-    rawDeadlyStrikeChance: roundStrikeValue(rawDeadlyStrikeChance),
-    rawMaxDeadlyStrikeChance: roundStrikeValue(rawMaxDeadlyStrikeChance),
-    deadlyStrikeChance: roundStrikeValue(deadlyStrikeChance),
-    maxDeadlyStrikeChance: roundStrikeValue(maxDeadlyStrikeChance),
-    effectiveDeadlyStrikeChance: roundStrikeValue(
-      deadlyStrikeChance * (1 - criticalChance / 100)
-    ),
-    deadlyStrikeMultiplier: roundStrikeValue(deadlyStrikeMultiplier),
-  };
-}
-
-function rebuildStrikeDamageComponents(
-  components: DamageProfile["damageComponents"],
-  strikeBreakdowns: DamageProfile["strikeBreakdowns"]
-): DamageProfile["damageComponents"] {
-  if (strikeBreakdowns.length === 0) {
-    return components;
-  }
-
-  const baseComponents = components.filter(
-    (component) =>
-      component.damageType !== "critical" && component.damageType !== "deadly"
-  );
-  const componentsById = new Map(
-    baseComponents.map((component) => [component.id, component])
-  );
-  const strikeComponents = strikeBreakdowns.flatMap((strike) => {
-    const physicalDamage = strike.physicalComponentIds.reduce(
-      (total, componentId) => {
-        const component = componentsById.get(componentId);
-        return component &&
-          component.damageType === "physical" &&
-          component.timing === "instant"
-          ? addRange(total, component.damage)
-          : total;
-      },
-      createEmptyRange()
-    );
-    if (!hasRange(physicalDamage)) {
-      return [];
-    }
-
-    return (
-      [
-        {
-          type: "critical" as const,
-          label: "Critical Strike bonus",
-          chance: strike.criticalChance,
-          multiplier: strike.criticalMultiplier,
-        },
-        {
-          type: "deadly" as const,
-          label: "Deadly Strike bonus",
-          chance: strike.effectiveDeadlyStrikeChance,
-          multiplier: strike.deadlyStrikeMultiplier,
-        },
-      ] as const
-    ).flatMap((outcome) => {
-      const expectedMultiplier =
-        (outcome.chance / 100) * (outcome.multiplier - 1);
-      const damage = scaleRange(physicalDamage, expectedMultiplier);
-      if (!hasRange(damage)) {
-        return [];
-      }
-
-      return [
-        {
-          id: `strike:${strike.id}:${outcome.type}`,
-          label:
-            strike.label === "Attack"
-              ? outcome.label
-              : `${strike.label}: ${outcome.label}`,
-          source: "stat" as const,
-          damageType: outcome.type,
-          timing: "instant" as const,
-          damage,
-          sourceRefs: STRIKE_DAMAGE_SOURCE_REFS,
-          notes: [],
-        },
-      ];
-    });
-  });
-
-  return [...baseComponents, ...strikeComponents];
 }
 
 function buildAuraSummary(

--- a/web/src/components/character/DamageCalculatorSection.tsx
+++ b/web/src/components/character/DamageCalculatorSection.tsx
@@ -29,6 +29,24 @@ import { STAT_COLORS } from "./stat-colors";
 const SPELL_AURA_DAMAGE_NOTE =
   "Selected attack aura damage payloads are not applied to spell damage.";
 
+const BASE_CRITICAL_STRIKE_CHANCE_CAP = 75;
+
+const EMPTY_STRIKE_MODIFIERS: DamageAuraOption["levelBonuses"][number]["strikeModifiers"] =
+  {
+    criticalChance: 0,
+    deadlyStrikeChance: 0,
+    maxDeadlyStrikeChance: 0,
+    criticalMultiplierBonus: 0,
+    deadlyStrikeMultiplierBonus: 0,
+  };
+
+const STRIKE_DAMAGE_SOURCE_REFS = [
+  {
+    table: "Skills.txt / item stats",
+    columns: ["Critical / Deadly Strike"],
+  },
+];
+
 function formatNumber(value: number, round = false) {
   const numericValue = Number(value);
   if (!Number.isFinite(numericValue)) {
@@ -46,16 +64,20 @@ function formatRange(range?: DamageRange, round = false) {
   return `${formatNumber(range.min, round)} - ${formatNumber(range.max, round)}`;
 }
 
+function formatDamageNumber(value: number) {
+  return formatNumber(value, true);
+}
+
+function formatDamageRange(range?: DamageRange) {
+  return formatRange(range, true);
+}
+
 function shouldRoundProfileOutput(profile: DamageProfile) {
   return profile.chargeVariant === "average";
 }
 
 function formatProfileNumber(profile: DamageProfile, value: number) {
   return formatNumber(value, shouldRoundProfileOutput(profile));
-}
-
-function formatProfileRange(profile: DamageProfile, range?: DamageRange) {
-  return formatRange(range, shouldRoundProfileOutput(profile));
 }
 
 function formatProfilePercent(profile: DamageProfile, value: number) {
@@ -244,6 +266,8 @@ function getTransformationBonus(
 const DAMAGE_ELEMENTS = ["fire", "cold", "lightning", "magic"] as const;
 const DAMAGE_TYPE_COLORS: Record<string, string> = {
   physical: STAT_COLORS.physicalDamageReduction,
+  critical: "#c084fc",
+  deadly: "#f472b6",
   fire: STAT_COLORS.fire,
   cold: STAT_COLORS.cold,
   lightning: STAT_COLORS.lightning,
@@ -422,6 +446,7 @@ function getAuraLevelBonus(
     skillLevelBonus: 0,
     physicalBonusPercent: 0,
     elementalDamage: {},
+    strikeModifiers: { ...EMPTY_STRIKE_MODIFIERS },
   };
 
   if (!auraOption || auraOption.id === "none") {
@@ -454,10 +479,14 @@ function getAuraBonusScore(
     return total + (range ? (range.min + range.max) / 2 : 0);
   }, 0);
   const poisonScore = bonus.poisonDamage?.total ?? 0;
+  const strikeScore = Object.values(
+    bonus.strikeModifiers ?? EMPTY_STRIKE_MODIFIERS
+  ).reduce((total, value) => total + Math.abs(value), 0);
 
   return (
     bonus.skillLevelBonus * 1000000 +
     bonus.physicalBonusPercent * 1000 +
+    strikeScore * 1000 +
     elementalScore +
     poisonScore
   );
@@ -616,6 +645,19 @@ function getDamageScopeCountLabel(profile: DamageProfile) {
   return `${scope.count.toLocaleString()} ${scope.countLabel}`;
 }
 
+function getStrikeSummary(profile: DamageProfile, type: "critical" | "deadly") {
+  if (profile.strikeBreakdowns.length !== 1) {
+    return profile.strikeBreakdowns.length > 1
+      ? "Per-weapon chances shown below"
+      : "No eligible strike roll";
+  }
+
+  const strike = profile.strikeBreakdowns[0];
+  return type === "critical"
+    ? `${formatProfilePercent(profile, strike.criticalChance)} at ${formatProfileNumber(profile, strike.criticalMultiplier)}x`
+    : `${formatProfilePercent(profile, strike.effectiveDeadlyStrikeChance)} effective at ${formatProfileNumber(profile, strike.deadlyStrikeMultiplier)}x`;
+}
+
 function getDamageModelDisplayNotes(
   profile: DamageProfile,
   weapon?: DamageWeaponOption | null
@@ -650,6 +692,16 @@ function getDamageModelDisplayNotes(
     notes.push(
       "Paired-weapon skills show the modeled weapon sequence, not a full movement or animation hit count."
     );
+  }
+
+  if (profile.strikeBreakdowns.length > 0) {
+    notes.push(
+      "CS & DS values are expected values. CS is rolled before DS."
+    );
+  }
+
+  if (profile.skillName === "Smite") {
+    notes.push("Critical Strike and Deadly Strike do not apply to Smite.");
   }
 
   if (profile.skillDamageMode === "summon") {
@@ -831,6 +883,7 @@ type RuntimeDamageProfile = Omit<
   | "activeAuras"
   | "breakdown"
   | "damageComponents"
+  | "strikeBreakdowns"
   | "damageTotals"
   | "auraPulseDamageComponents"
   | "auraPulseDamageTotals"
@@ -847,6 +900,7 @@ type RuntimeDamageProfile = Omit<
       | "activeAuras"
       | "breakdown"
       | "damageComponents"
+      | "strikeBreakdowns"
       | "damageTotals"
       | "auraPulseDamageComponents"
       | "auraPulseDamageTotals"
@@ -1061,6 +1115,7 @@ function normalizeDamageProfile(profile: DamageProfile): DamageProfile {
     ...profile,
     activeAuras: runtimeProfile.activeAuras ?? [],
     damageComponents,
+    strikeBreakdowns: runtimeProfile.strikeBreakdowns ?? [],
     damageTotals,
     auraPulseDamageComponents,
     auraPulseDamageTotals,
@@ -1116,6 +1171,144 @@ function rescalePhysicalComponents(
       },
     };
   });
+}
+
+function roundStrikeValue(value: number) {
+  return Number(value.toFixed(3));
+}
+
+function applyStrikeModifierDelta(
+  strike: DamageProfile["strikeBreakdowns"][number],
+  next: DamageAuraOption["levelBonuses"][number]["strikeModifiers"],
+  previous: DamageAuraOption["levelBonuses"][number]["strikeModifiers"]
+): DamageProfile["strikeBreakdowns"][number] {
+  const rawCriticalChance = Math.max(
+    0,
+    strike.rawCriticalChance + next.criticalChance - previous.criticalChance
+  );
+  const criticalChance = Math.min(
+    BASE_CRITICAL_STRIKE_CHANCE_CAP,
+    rawCriticalChance
+  );
+  const rawMaxDeadlyStrikeChance = Math.max(
+    0,
+    strike.rawMaxDeadlyStrikeChance +
+      next.maxDeadlyStrikeChance -
+      previous.maxDeadlyStrikeChance
+  );
+  const maxDeadlyStrikeChance = Math.min(100, rawMaxDeadlyStrikeChance);
+  const rawDeadlyStrikeChance = Math.max(
+    0,
+    strike.rawDeadlyStrikeChance +
+      next.deadlyStrikeChance -
+      previous.deadlyStrikeChance
+  );
+  const deadlyStrikeChance = Math.min(
+    maxDeadlyStrikeChance,
+    rawDeadlyStrikeChance
+  );
+  const criticalMultiplier = Math.max(
+    1,
+    strike.criticalMultiplier +
+      (next.criticalMultiplierBonus - previous.criticalMultiplierBonus) / 100
+  );
+  const deadlyStrikeMultiplier = Math.max(
+    1,
+    strike.deadlyStrikeMultiplier +
+      (next.deadlyStrikeMultiplierBonus -
+        previous.deadlyStrikeMultiplierBonus) /
+        100
+  );
+
+  return {
+    ...strike,
+    rawCriticalChance: roundStrikeValue(rawCriticalChance),
+    criticalChance: roundStrikeValue(criticalChance),
+    criticalMultiplier: roundStrikeValue(criticalMultiplier),
+    rawDeadlyStrikeChance: roundStrikeValue(rawDeadlyStrikeChance),
+    rawMaxDeadlyStrikeChance: roundStrikeValue(rawMaxDeadlyStrikeChance),
+    deadlyStrikeChance: roundStrikeValue(deadlyStrikeChance),
+    maxDeadlyStrikeChance: roundStrikeValue(maxDeadlyStrikeChance),
+    effectiveDeadlyStrikeChance: roundStrikeValue(
+      deadlyStrikeChance * (1 - criticalChance / 100)
+    ),
+    deadlyStrikeMultiplier: roundStrikeValue(deadlyStrikeMultiplier),
+  };
+}
+
+function rebuildStrikeDamageComponents(
+  components: DamageProfile["damageComponents"],
+  strikeBreakdowns: DamageProfile["strikeBreakdowns"]
+): DamageProfile["damageComponents"] {
+  if (strikeBreakdowns.length === 0) {
+    return components;
+  }
+
+  const baseComponents = components.filter(
+    (component) =>
+      component.damageType !== "critical" && component.damageType !== "deadly"
+  );
+  const componentsById = new Map(
+    baseComponents.map((component) => [component.id, component])
+  );
+  const strikeComponents = strikeBreakdowns.flatMap((strike) => {
+    const physicalDamage = strike.physicalComponentIds.reduce(
+      (total, componentId) => {
+        const component = componentsById.get(componentId);
+        return component &&
+          component.damageType === "physical" &&
+          component.timing === "instant"
+          ? addRange(total, component.damage)
+          : total;
+      },
+      createEmptyRange()
+    );
+    if (!hasRange(physicalDamage)) {
+      return [];
+    }
+
+    return (
+      [
+        {
+          type: "critical" as const,
+          label: "Critical Strike bonus",
+          chance: strike.criticalChance,
+          multiplier: strike.criticalMultiplier,
+        },
+        {
+          type: "deadly" as const,
+          label: "Deadly Strike bonus",
+          chance: strike.effectiveDeadlyStrikeChance,
+          multiplier: strike.deadlyStrikeMultiplier,
+        },
+      ] as const
+    ).flatMap((outcome) => {
+      const expectedMultiplier =
+        (outcome.chance / 100) * (outcome.multiplier - 1);
+      const damage = scaleRange(physicalDamage, expectedMultiplier);
+      if (!hasRange(damage)) {
+        return [];
+      }
+
+      return [
+        {
+          id: `strike:${strike.id}:${outcome.type}`,
+          label:
+            strike.label === "Attack"
+              ? outcome.label
+              : `${strike.label}: ${outcome.label}`,
+          source: "stat" as const,
+          damageType: outcome.type,
+          timing: "instant" as const,
+          damage,
+          sourceRefs: STRIKE_DAMAGE_SOURCE_REFS,
+          notes: [],
+        },
+      ];
+    });
+  });
+
+  return [...baseComponents, ...strikeComponents];
 }
 
 function buildAuraSummary(
@@ -1202,6 +1395,13 @@ function applyAuraToProfile(
     Boolean(existingAura) && existingAura!.level >= numericLevel;
   const effectiveAura = existingAuraIsStronger ? existingAura! : selectedAura;
   const nextBonus = existingAuraIsStronger ? existingBonus : selectedBonus;
+  const strikeBreakdowns = profile.strikeBreakdowns.map((strike) =>
+    applyStrikeModifierDelta(
+      strike,
+      nextBonus.strikeModifiers ?? EMPTY_STRIKE_MODIFIERS,
+      existingBonus.strikeModifiers ?? EMPTY_STRIKE_MODIFIERS
+    )
+  );
 
   if (profile.skillDamageMode === "spell") {
     return {
@@ -1235,7 +1435,8 @@ function applyAuraToProfile(
   const previousMultiplier = 1 + previousTotalBonus / 100;
   const nextMultiplier = 1 + nextTotalBonus / 100;
   const sequenceHitCount = getProfileSequenceHitCount(profile);
-  const auraDeltaComponents = DAMAGE_ELEMENTS.flatMap((element) => {
+  const isSmiteProfile = profile.skillName === "Smite";
+  const auraDeltaComponents = (isSmiteProfile ? [] : DAMAGE_ELEMENTS).flatMap((element) => {
     const damage = elementalDelta[element];
     if (!hasRange(damage)) {
       return [];
@@ -1271,7 +1472,7 @@ function applyAuraToProfile(
       },
     ];
   });
-  const poisonDeltaComponents = poisonDelta
+  const poisonDeltaComponents = !isSmiteProfile && poisonDelta
     ? [
         {
           id: `selected-aura:${auraOption.id}:${numericLevel}:${selectedAura.carrier}:poison`,
@@ -1313,15 +1514,18 @@ function applyAuraToProfile(
         },
       ]
     : [];
-  const damageComponents = [
-    ...rescalePhysicalComponents(
-      profile.damageComponents,
-      previousMultiplier,
-      nextMultiplier
-    ),
-    ...auraDeltaComponents,
-    ...poisonDeltaComponents,
-  ].filter((component) => hasRange(component.damage));
+  const damageComponents = rebuildStrikeDamageComponents(
+    [
+      ...rescalePhysicalComponents(
+        profile.damageComponents,
+        previousMultiplier,
+        nextMultiplier
+      ),
+      ...auraDeltaComponents,
+      ...poisonDeltaComponents,
+    ].filter((component) => hasRange(component.damage)),
+    strikeBreakdowns
+  );
   const summary = summaryFieldsFromComponents(damageComponents);
 
   return {
@@ -1337,6 +1541,7 @@ function applyAuraToProfile(
     },
     activeAuras: replaceAuraSummary(profile.activeAuras, effectiveAura),
     damageComponents,
+    strikeBreakdowns,
     ...summary,
     breakdown: {
       ...profile.breakdown,
@@ -1394,10 +1599,13 @@ function applyTransformationToProfile(
   const nextTotalBonus = previousTotalBonus + transformationBonus;
   const previousMultiplier = 1 + previousTotalBonus / 100;
   const nextMultiplier = 1 + nextTotalBonus / 100;
-  const damageComponents = rescalePhysicalComponents(
-    profile.damageComponents,
-    previousMultiplier,
-    nextMultiplier
+  const damageComponents = rebuildStrikeDamageComponents(
+    rescalePhysicalComponents(
+      profile.damageComponents,
+      previousMultiplier,
+      nextMultiplier
+    ),
+    profile.strikeBreakdowns
   );
   const summary = summaryFieldsFromComponents(damageComponents);
 
@@ -2333,15 +2541,13 @@ export function DamageCalculatorSection({
                       ),
                     }}
                   >
-                    {formatProfileRange(
-                      selectedProfile,
+                    {formatDamageRange(
                       selectedProfile.damageTotals.combinedDamage
                     )}
                   </Text>
                   <Text size="xs" c="dimmed">
                     Avg{" "}
-                    {formatProfileNumber(
-                      selectedProfile,
+                    {formatDamageNumber(
                       selectedProfile.damageTotals.averageCombinedDamage
                     )}
                   </Text>
@@ -2353,8 +2559,7 @@ export function DamageCalculatorSection({
                   {selectedProfile.auraPulseDamageTotals ? (
                     <Text size="xs" c="dimmed">
                       Pulse{" "}
-                      {formatProfileRange(
-                        selectedProfile,
+                      {formatDamageRange(
                         selectedProfile.auraPulseDamageTotals.combinedDamage
                       )}
                     </Text>
@@ -2516,7 +2721,7 @@ export function DamageCalculatorSection({
 
           {selectedProfile ? (
             <>
-              <SimpleGrid cols={{ base: 1, sm: 2, lg: 5 }}>
+              <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }}>
                 <Card
                   withBorder
                   padding="sm"
@@ -2537,15 +2742,13 @@ export function DamageCalculatorSection({
                       ),
                     }}
                   >
-                    {formatProfileRange(
-                      selectedProfile,
+                    {formatDamageRange(
                       selectedProfile.damageTotals.combinedDamage
                     )}
                   </Text>
                   <Text size="xs" c="dimmed">
                     Avg{" "}
-                    {formatProfileNumber(
-                      selectedProfile,
+                    {formatDamageNumber(
                       selectedProfile.damageTotals.averageCombinedDamage
                     )}
                   </Text>
@@ -2576,17 +2779,73 @@ export function DamageCalculatorSection({
                       ),
                     }}
                   >
-                    {formatProfileRange(
-                      selectedProfile,
+                    {formatDamageRange(
                       selectedProfile.damageTotals.instantDamage
                     )}
                   </Text>
                   <Text size="xs" c="dimmed">
                     Avg{" "}
-                    {formatProfileNumber(
-                      selectedProfile,
+                    {formatDamageNumber(
                       selectedProfile.damageTotals.averageInstantDamage
                     )}
+                  </Text>
+                </Card>
+
+                <Card
+                  withBorder
+                  padding="sm"
+                  style={{
+                    borderTop: `0.1875rem solid ${DAMAGE_TYPE_COLORS.critical}`,
+                  }}
+                >
+                  <Text size="xs" c="dimmed" tt="uppercase">
+                    Critical Strike Bonus
+                  </Text>
+                  <Text
+                    size="lg"
+                    fw={700}
+                    style={{
+                      color: getRangeColor(
+                        selectedProfile.damageTotals.byElement.critical,
+                        DAMAGE_TYPE_COLORS.critical
+                      ),
+                    }}
+                  >
+                    {formatDamageRange(
+                      selectedProfile.damageTotals.byElement.critical
+                    )}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    {getStrikeSummary(selectedProfile, "critical")}
+                  </Text>
+                </Card>
+
+                <Card
+                  withBorder
+                  padding="sm"
+                  style={{
+                    borderTop: `0.1875rem solid ${DAMAGE_TYPE_COLORS.deadly}`,
+                  }}
+                >
+                  <Text size="xs" c="dimmed" tt="uppercase">
+                    Deadly Strike Bonus
+                  </Text>
+                  <Text
+                    size="lg"
+                    fw={700}
+                    style={{
+                      color: getRangeColor(
+                        selectedProfile.damageTotals.byElement.deadly,
+                        DAMAGE_TYPE_COLORS.deadly
+                      ),
+                    }}
+                  >
+                    {formatDamageRange(
+                      selectedProfile.damageTotals.byElement.deadly
+                    )}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    {getStrikeSummary(selectedProfile, "deadly")}
                   </Text>
                 </Card>
 
@@ -2610,10 +2869,7 @@ export function DamageCalculatorSection({
                       ),
                     }}
                   >
-                    {formatProfileRange(
-                      selectedProfile,
-                      selectedProfile.totalPhysicalDamage
-                    )}
+                    {formatDamageRange(selectedProfile.totalPhysicalDamage)}
                   </Text>
                   <Text size="xs" c="dimmed">
                     {`+${formatProfilePercent(
@@ -2678,16 +2934,14 @@ export function DamageCalculatorSection({
                           ),
                         }}
                       >
-                        {formatProfileRange(
-                          selectedProfile,
+                        {formatDamageRange(
                           selectedProfile.damageTotals.overTimeDamage
                         )}
                       </Text>
                       {selectedProfile.totalPoisonDamage ? (
                         <Text size="xs" c="dimmed">
                           poison total{" "}
-                          {formatProfileNumber(
-                            selectedProfile,
+                          {formatDamageNumber(
                             selectedProfile.totalPoisonDamage.total
                           )}{" "}
                           over{" "}
@@ -2727,8 +2981,7 @@ export function DamageCalculatorSection({
                           ),
                         }}
                       >
-                        {formatProfileRange(
-                          selectedProfile,
+                        {formatDamageRange(
                           selectedProfile.auraPulseDamageTotals.combinedDamage
                         )}
                       </Text>
@@ -2747,15 +3000,43 @@ export function DamageCalculatorSection({
                             style={{ wordBreak: "break-word" }}
                           >
                             {component.label}:{" "}
-                            {formatProfileRange(
-                              selectedProfile,
-                              component.damage
-                            )}
+                            {formatDamageRange(component.damage)}
                           </Text>
                         )
                       )}
                     </Stack>
                   </Group>
+                </Card>
+              ) : null}
+
+              {selectedProfile.strikeBreakdowns.length > 0 ? (
+                <Card withBorder padding="sm">
+                  <Text fw={600} mb="xs">
+                    Critical / Deadly Strike
+                  </Text>
+                  <Stack gap="sm">
+                    {selectedProfile.strikeBreakdowns.map((strike) => (
+                      <div key={strike.id}>
+                        <Text size="sm" fw={500} mb={4}>
+                          {strike.label}
+                        </Text>
+                        <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+                          <Text size="xs" c="dimmed">
+                            Critical: {strike.rawCriticalChance}% raw,{" "}
+                            {strike.criticalChance}% capped,{" "}
+                            {strike.criticalMultiplier}x
+                          </Text>
+                          <Text size="xs" c="dimmed">
+                            Deadly: {strike.rawDeadlyStrikeChance}% raw,{" "}
+                            {strike.deadlyStrikeChance}% capped at{" "}
+                            {strike.maxDeadlyStrikeChance}%,{" "}
+                            {strike.effectiveDeadlyStrikeChance}% effective,{" "}
+                            {strike.deadlyStrikeMultiplier}x
+                          </Text>
+                        </SimpleGrid>
+                      </div>
+                    ))}
+                  </Stack>
                 </Card>
               ) : null}
 
@@ -2826,10 +3107,7 @@ export function DamageCalculatorSection({
                               ),
                             }}
                           >
-                            {formatProfileRange(
-                              selectedProfile,
-                              component.damage
-                            )}
+                            {formatDamageRange(component.damage)}
                           </Text>
                         </Group>
                       );
@@ -2858,7 +3136,7 @@ export function DamageCalculatorSection({
                           <StatLine
                             key={element}
                             label={element[0].toUpperCase() + element.slice(1)}
-                            value={formatProfileRange(selectedProfile, range)}
+                            value={formatDamageRange(range)}
                             color={getRangeColor(range, color)}
                             isLast={index === elements.length - 1}
                           />
@@ -2879,8 +3157,7 @@ export function DamageCalculatorSection({
                           ? "Summon base"
                           : "Weapon damage"
                       }
-                      value={formatProfileRange(
-                        selectedProfile,
+                      value={formatDamageRange(
                         selectedProfile.breakdown.weaponDamage
                       )}
                       color={getRangeColor(
@@ -2890,13 +3167,32 @@ export function DamageCalculatorSection({
                     />
                     <StatLine
                       label="Flat damage"
-                      value={formatProfileRange(
-                        selectedProfile,
+                      value={formatDamageRange(
                         selectedProfile.breakdown.flatPhysicalDamage
                       )}
                       color={getRangeColor(
                         selectedProfile.breakdown.flatPhysicalDamage,
                         STAT_COLORS.physicalDamageReduction
+                      )}
+                    />
+                    <StatLine
+                      label="Critical Strike bonus"
+                      value={formatDamageRange(
+                        selectedProfile.damageTotals.byElement.critical
+                      )}
+                      color={getRangeColor(
+                        selectedProfile.damageTotals.byElement.critical,
+                        DAMAGE_TYPE_COLORS.critical
+                      )}
+                    />
+                    <StatLine
+                      label="Deadly Strike bonus"
+                      value={formatDamageRange(
+                        selectedProfile.damageTotals.byElement.deadly
+                      )}
+                      color={getRangeColor(
+                        selectedProfile.damageTotals.byElement.deadly,
+                        DAMAGE_TYPE_COLORS.deadly
                       )}
                     />
                     <StatLine

--- a/web/src/components/character/StatsSection.tsx
+++ b/web/src/components/character/StatsSection.tsx
@@ -99,6 +99,7 @@ export function StatsSection({
     fasterRunWalk: 0,
     increasedAttackSpeed: 0,
     crushingBlow: 0,
+    criticalStrike: 0,
     deadlyStrike: 0,
     lifeLeech: 0,
     manaLeech: 0,
@@ -290,6 +291,11 @@ export function StatsSection({
             label="Crushing Blow"
             value={`${realStats.crushingBlow}%`}
             color={COLORS.crushingBlow}
+          />
+          <StatRow
+            label="Critical Strike"
+            value={`${realStats.criticalStrike ?? 0}%`}
+            color={COLORS.criticalStrike}
           />
           <StatRow
             label="Deadly Strike"

--- a/web/src/components/character/stat-colors.ts
+++ b/web/src/components/character/stat-colors.ts
@@ -22,6 +22,7 @@ export const STAT_COLORS = {
   fasterRunWalk: THEME_COLORS.green,
   increasedAttackSpeed: THEME_COLORS.blue,
   crushingBlow: THEME_COLORS.orange,
+  criticalStrike: THEME_COLORS.violet,
   deadlyStrike: THEME_COLORS.yellow,
   openWounds: THEME_COLORS.red,
   lifeLeech: THEME_COLORS.red,

--- a/web/src/types/character.ts
+++ b/web/src/types/character.ts
@@ -152,6 +152,7 @@ export interface RealStats {
   fasterHitRecovery: number;
   fasterRunWalk: number;
   crushingBlow: number;
+  criticalStrike: number;
   deadlyStrike: number;
   openWounds: number;
   openWoundsDPS: number;

--- a/web/src/types/damage.ts
+++ b/web/src/types/damage.ts
@@ -20,6 +20,8 @@ export type DamageElement =
   | "magic"
   | "poison";
 
+export type DamageType = DamageElement | "critical" | "deadly";
+
 export type DamageComponentSource =
   | "weapon"
   | "item"
@@ -42,11 +44,34 @@ export interface DamageSourceReference {
   note?: string;
 }
 
+export interface DamageStrikeModifiers {
+  criticalChance: number;
+  deadlyStrikeChance: number;
+  maxDeadlyStrikeChance: number;
+  criticalMultiplierBonus: number;
+  deadlyStrikeMultiplierBonus: number;
+}
+
+export interface DamageStrikeBreakdown {
+  id: string;
+  label: string;
+  physicalComponentIds: string[];
+  rawCriticalChance: number;
+  criticalChance: number;
+  criticalMultiplier: number;
+  rawDeadlyStrikeChance: number;
+  rawMaxDeadlyStrikeChance: number;
+  deadlyStrikeChance: number;
+  maxDeadlyStrikeChance: number;
+  effectiveDeadlyStrikeChance: number;
+  deadlyStrikeMultiplier: number;
+}
+
 export interface DamageComponent {
   id: string;
   label: string;
   source: DamageComponentSource;
-  damageType: DamageElement;
+  damageType: DamageType;
   timing: DamageComponentTiming;
   damage: DamageRange;
   baseDamage?: DamageRange;
@@ -62,7 +87,7 @@ export interface DamageTotals {
   combinedDamage: DamageRange;
   averageInstantDamage: number;
   averageCombinedDamage: number;
-  byElement: Partial<Record<DamageElement, DamageRange>>;
+  byElement: Partial<Record<DamageType, DamageRange>>;
   poisonDamage?: PoisonDamage;
 }
 
@@ -76,6 +101,7 @@ export interface DamageWeaponOption {
     | "two_handed"
     | "missile"
     | "kick"
+    | "smite"
     | "summon"
     | "unarmed"
     | "dual_wield"
@@ -122,6 +148,7 @@ export interface DamageAuraLevelBonus {
     Record<Exclude<DamageElement, "physical" | "poison">, DamageRange>
   >;
   poisonDamage?: PoisonDamagePayload;
+  strikeModifiers: DamageStrikeModifiers;
 }
 
 export interface DamageTransformationOption {
@@ -213,6 +240,7 @@ export interface DamageProfile {
   activeAuras: ActiveAuraSummary[];
   damageScope: DamageProfileScope;
   damageComponents: DamageComponent[];
+  strikeBreakdowns: DamageStrikeBreakdown[];
   damageTotals: DamageTotals;
   auraPulseDamageComponents?: DamageComponent[];
   auraPulseDamageTotals?: DamageTotals;

--- a/web/src/utils/damage-profile-adjustments.test.ts
+++ b/web/src/utils/damage-profile-adjustments.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import type {
+  DamageComponent,
+  DamageStrikeBreakdown,
+  DamageStrikeModifiers,
+} from "../types";
+import {
+  applyStrikeModifierDelta,
+  rebuildStrikeDamageComponents,
+  rescalePhysicalComponents,
+} from "./damage-profile-adjustments";
+
+const EMPTY_STRIKE_MODIFIERS: DamageStrikeModifiers = {
+  criticalChance: 0,
+  deadlyStrikeChance: 0,
+  maxDeadlyStrikeChance: 0,
+  criticalMultiplierBonus: 0,
+  deadlyStrikeMultiplierBonus: 0,
+};
+
+function createStrike(
+  overrides: Partial<DamageStrikeBreakdown> = {}
+): DamageStrikeBreakdown {
+  return {
+    id: "attack",
+    label: "Attack",
+    physicalComponentIds: ["physical"],
+    rawCriticalChance: 0,
+    criticalChance: 0,
+    criticalMultiplier: 2,
+    rawDeadlyStrikeChance: 0,
+    rawMaxDeadlyStrikeChance: 75,
+    deadlyStrikeChance: 0,
+    maxDeadlyStrikeChance: 75,
+    effectiveDeadlyStrikeChance: 0,
+    deadlyStrikeMultiplier: 1.5,
+    ...overrides,
+  };
+}
+
+function createPhysicalComponent(
+  id: string,
+  min: number,
+  max: number
+): DamageComponent {
+  return {
+    id,
+    label: id,
+    source: "weapon",
+    damageType: "physical",
+    timing: "instant",
+    damage: { min, max },
+    sourceRefs: [],
+    notes: [],
+  };
+}
+
+describe("damage profile strike adjustments", () => {
+  it("applies multiple strike aura deltas in sequence with caps and CS-first DS effectiveness", () => {
+    const firstAura: DamageStrikeModifiers = {
+      criticalChance: 20,
+      deadlyStrikeChance: 20,
+      maxDeadlyStrikeChance: 5,
+      criticalMultiplierBonus: 50,
+      deadlyStrikeMultiplierBonus: 25,
+    };
+    const secondAura: DamageStrikeModifiers = {
+      criticalChance: 5,
+      deadlyStrikeChance: 10,
+      maxDeadlyStrikeChance: 10,
+      criticalMultiplierBonus: 10,
+      deadlyStrikeMultiplierBonus: 20,
+    };
+    const initial = createStrike({
+      rawCriticalChance: 60,
+      criticalChance: 60,
+      rawDeadlyStrikeChance: 60,
+      deadlyStrikeChance: 60,
+      effectiveDeadlyStrikeChance: 24,
+    });
+
+    const afterFirst = applyStrikeModifierDelta(
+      initial,
+      firstAura,
+      EMPTY_STRIKE_MODIFIERS
+    );
+    const afterSecond = applyStrikeModifierDelta(
+      afterFirst,
+      secondAura,
+      EMPTY_STRIKE_MODIFIERS
+    );
+
+    expect(afterFirst).toMatchObject({
+      rawCriticalChance: 80,
+      criticalChance: 75,
+      criticalMultiplier: 2.5,
+      rawDeadlyStrikeChance: 80,
+      rawMaxDeadlyStrikeChance: 80,
+      deadlyStrikeChance: 80,
+      maxDeadlyStrikeChance: 80,
+      effectiveDeadlyStrikeChance: 20,
+      deadlyStrikeMultiplier: 1.75,
+    });
+    expect(afterSecond).toMatchObject({
+      rawCriticalChance: 85,
+      criticalChance: 75,
+      criticalMultiplier: 2.6,
+      rawDeadlyStrikeChance: 90,
+      rawMaxDeadlyStrikeChance: 90,
+      deadlyStrikeChance: 90,
+      maxDeadlyStrikeChance: 90,
+      effectiveDeadlyStrikeChance: 22.5,
+      deadlyStrikeMultiplier: 1.95,
+    });
+  });
+
+  it("rebuilds separate expected strike components for each dual-wield hit", () => {
+    const components = [
+      createPhysicalComponent("right-physical", 100, 200),
+      createPhysicalComponent("left-physical", 50, 80),
+    ];
+    const strikes = [
+      createStrike({
+        id: "right",
+        label: "Right hit",
+        physicalComponentIds: ["right-physical"],
+        criticalChance: 50,
+        effectiveDeadlyStrikeChance: 25,
+      }),
+      createStrike({
+        id: "left",
+        label: "Left hit",
+        physicalComponentIds: ["left-physical"],
+        criticalChance: 25,
+        effectiveDeadlyStrikeChance: 50,
+      }),
+    ];
+
+    const rebuilt = rebuildStrikeDamageComponents(components, strikes);
+
+    expect(
+      rebuilt
+        .filter((component) =>
+          ["critical", "deadly"].includes(component.damageType)
+        )
+        .map(({ id, label, damage }) => ({ id, label, damage }))
+    ).toEqual([
+      {
+        id: "strike:right:critical",
+        label: "Right hit: Critical Strike bonus",
+        damage: { min: 50, max: 100 },
+      },
+      {
+        id: "strike:right:deadly",
+        label: "Right hit: Deadly Strike bonus",
+        damage: { min: 12.5, max: 25 },
+      },
+      {
+        id: "strike:left:critical",
+        label: "Left hit: Critical Strike bonus",
+        damage: { min: 12.5, max: 20 },
+      },
+      {
+        id: "strike:left:deadly",
+        label: "Left hit: Deadly Strike bonus",
+        damage: { min: 12.5, max: 20 },
+      },
+    ]);
+  });
+
+  it("rebuilds expected strike damage from rescaled physical components", () => {
+    const physical = {
+      ...createPhysicalComponent("physical", 150, 300),
+      baseDamage: { min: 100, max: 200 },
+    };
+    const staleCritical: DamageComponent = {
+      ...createPhysicalComponent("strike:attack:critical", 75, 150),
+      damageType: "critical",
+    };
+    const strike = createStrike({
+      criticalChance: 50,
+      effectiveDeadlyStrikeChance: 0,
+    });
+
+    const rescaled = rescalePhysicalComponents(
+      [physical, staleCritical],
+      1.5,
+      2
+    );
+    const rebuilt = rebuildStrikeDamageComponents(rescaled, [strike]);
+
+    expect(
+      rebuilt.find((component) => component.id === "physical")
+    ).toMatchObject({
+      baseDamage: { min: 100, max: 200 },
+      damage: { min: 200, max: 400 },
+    });
+    expect(
+      rebuilt.find((component) => component.id === "strike:attack:critical")
+    ).toMatchObject({
+      damageType: "critical",
+      damage: { min: 100, max: 200 },
+    });
+  });
+});

--- a/web/src/utils/damage-profile-adjustments.ts
+++ b/web/src/utils/damage-profile-adjustments.ts
@@ -1,0 +1,209 @@
+import type { DamageAuraOption, DamageProfile, DamageRange } from "../types";
+
+const BASE_CRITICAL_STRIKE_CHANCE_CAP = 75;
+
+const STRIKE_DAMAGE_SOURCE_REFS = [
+  {
+    table: "Skills.txt / item stats",
+    columns: ["Critical / Deadly Strike"],
+  },
+];
+
+function createEmptyRange(): DamageRange {
+  return { min: 0, max: 0 };
+}
+
+function addRange(base: DamageRange, addition?: DamageRange): DamageRange {
+  if (!addition) {
+    return base;
+  }
+
+  return {
+    min: base.min + addition.min,
+    max: base.max + addition.max,
+  };
+}
+
+function scaleRange(range: DamageRange, multiplier: number): DamageRange {
+  return {
+    min: range.min * multiplier,
+    max: range.max * multiplier,
+  };
+}
+
+function hasRange(range?: DamageRange | null): range is DamageRange {
+  return Boolean(range && (range.min > 0 || range.max > 0));
+}
+
+function roundStrikeValue(value: number) {
+  return Number(value.toFixed(3));
+}
+
+export function rescalePhysicalComponents(
+  components: DamageProfile["damageComponents"],
+  previousMultiplier: number,
+  nextMultiplier: number
+): DamageProfile["damageComponents"] {
+  return components.map((component) => {
+    if (component.damageType !== "physical" || component.timing !== "instant") {
+      return component;
+    }
+
+    const baseDamage = component.baseDamage || {
+      min:
+        previousMultiplier === 0
+          ? component.damage.min
+          : component.damage.min / previousMultiplier,
+      max:
+        previousMultiplier === 0
+          ? component.damage.max
+          : component.damage.max / previousMultiplier,
+    };
+
+    return {
+      ...component,
+      baseDamage,
+      damage: {
+        min: Math.floor(baseDamage.min * nextMultiplier),
+        max: Math.max(
+          Math.floor(baseDamage.min * nextMultiplier),
+          Math.floor(baseDamage.max * nextMultiplier)
+        ),
+      },
+    };
+  });
+}
+
+export function applyStrikeModifierDelta(
+  strike: DamageProfile["strikeBreakdowns"][number],
+  next: DamageAuraOption["levelBonuses"][number]["strikeModifiers"],
+  previous: DamageAuraOption["levelBonuses"][number]["strikeModifiers"]
+): DamageProfile["strikeBreakdowns"][number] {
+  const rawCriticalChance = Math.max(
+    0,
+    strike.rawCriticalChance + next.criticalChance - previous.criticalChance
+  );
+  const criticalChance = Math.min(
+    BASE_CRITICAL_STRIKE_CHANCE_CAP,
+    rawCriticalChance
+  );
+  const rawMaxDeadlyStrikeChance = Math.max(
+    0,
+    strike.rawMaxDeadlyStrikeChance +
+      next.maxDeadlyStrikeChance -
+      previous.maxDeadlyStrikeChance
+  );
+  const maxDeadlyStrikeChance = Math.min(100, rawMaxDeadlyStrikeChance);
+  const rawDeadlyStrikeChance = Math.max(
+    0,
+    strike.rawDeadlyStrikeChance +
+      next.deadlyStrikeChance -
+      previous.deadlyStrikeChance
+  );
+  const deadlyStrikeChance = Math.min(
+    maxDeadlyStrikeChance,
+    rawDeadlyStrikeChance
+  );
+  const criticalMultiplier = Math.max(
+    1,
+    strike.criticalMultiplier +
+      (next.criticalMultiplierBonus - previous.criticalMultiplierBonus) / 100
+  );
+  const deadlyStrikeMultiplier = Math.max(
+    1,
+    strike.deadlyStrikeMultiplier +
+      (next.deadlyStrikeMultiplierBonus -
+        previous.deadlyStrikeMultiplierBonus) /
+        100
+  );
+
+  return {
+    ...strike,
+    rawCriticalChance: roundStrikeValue(rawCriticalChance),
+    criticalChance: roundStrikeValue(criticalChance),
+    criticalMultiplier: roundStrikeValue(criticalMultiplier),
+    rawDeadlyStrikeChance: roundStrikeValue(rawDeadlyStrikeChance),
+    rawMaxDeadlyStrikeChance: roundStrikeValue(rawMaxDeadlyStrikeChance),
+    deadlyStrikeChance: roundStrikeValue(deadlyStrikeChance),
+    maxDeadlyStrikeChance: roundStrikeValue(maxDeadlyStrikeChance),
+    effectiveDeadlyStrikeChance: roundStrikeValue(
+      deadlyStrikeChance * (1 - criticalChance / 100)
+    ),
+    deadlyStrikeMultiplier: roundStrikeValue(deadlyStrikeMultiplier),
+  };
+}
+
+export function rebuildStrikeDamageComponents(
+  components: DamageProfile["damageComponents"],
+  strikeBreakdowns: DamageProfile["strikeBreakdowns"]
+): DamageProfile["damageComponents"] {
+  if (strikeBreakdowns.length === 0) {
+    return components;
+  }
+
+  const baseComponents = components.filter(
+    (component) =>
+      component.damageType !== "critical" && component.damageType !== "deadly"
+  );
+  const componentsById = new Map(
+    baseComponents.map((component) => [component.id, component])
+  );
+  const strikeComponents = strikeBreakdowns.flatMap((strike) => {
+    const physicalDamage = strike.physicalComponentIds.reduce(
+      (total, componentId) => {
+        const component = componentsById.get(componentId);
+        return component &&
+          component.damageType === "physical" &&
+          component.timing === "instant"
+          ? addRange(total, component.damage)
+          : total;
+      },
+      createEmptyRange()
+    );
+    if (!hasRange(physicalDamage)) {
+      return [];
+    }
+
+    return (
+      [
+        {
+          type: "critical" as const,
+          label: "Critical Strike bonus",
+          chance: strike.criticalChance,
+          multiplier: strike.criticalMultiplier,
+        },
+        {
+          type: "deadly" as const,
+          label: "Deadly Strike bonus",
+          chance: strike.effectiveDeadlyStrikeChance,
+          multiplier: strike.deadlyStrikeMultiplier,
+        },
+      ] as const
+    ).flatMap((outcome) => {
+      const expectedMultiplier =
+        (outcome.chance / 100) * (outcome.multiplier - 1);
+      const damage = scaleRange(physicalDamage, expectedMultiplier);
+      if (!hasRange(damage)) {
+        return [];
+      }
+
+      return [
+        {
+          id: `strike:${strike.id}:${outcome.type}`,
+          label:
+            strike.label === "Attack"
+              ? outcome.label
+              : `${strike.label}: ${outcome.label}`,
+          source: "stat" as const,
+          damageType: outcome.type,
+          timing: "instant" as const,
+          damage,
+          sourceRefs: STRIKE_DAMAGE_SOURCE_REFS,
+          notes: [],
+        },
+      ];
+    });
+  });
+
+  return [...baseComponents, ...strikeComponents];
+}


### PR DESCRIPTION
## Summary

- model Critical Strike and Deadly Strike as separate expected-value damage types for eligible instant physical attacks, with Critical Strike rolled before effective Deadly Strike
- derive strike chance, caps, and variable multipliers from item, passive, skill, and aura sources
- model Smite from equipped-shield damage plus Holy Shield and its Defiance synergy
- expose the new physical breakdown, character-page item CS/DS totals, and mechanics notes in the UI, with focused API/Vitest coverage and a frontend CI test gate

**calculator page**
<img width="879" height="342" alt="image" src="https://github.com/user-attachments/assets/71d53186-f6a4-4f9b-8ec3-6d0a802d5e1c" />

**character page**
<img width="933" height="991" alt="image" src="https://github.com/user-attachments/assets/fc679cb9-de51-42d8-915b-b0224f36fb06" />

## Why

The calculator previously omitted expected CS/DS damage and used incomplete damage sources for Smite. Profiles now include base physical, Critical Strike, and Deadly Strike damage separately while keeping physical spells ineligible; Smite uses the equipped shield and active Holy Shield calculation.

## Validation

- focused API tests: 135 passed; frontend tests: 3 passed
- frontend lint, type-check, and build passed; both GitHub Actions jobs passed
- fresh live snapshot: 229 samples across 78/148 season-13 softcore skill-mode pairs, including 78 CS and 54 DS profiles
- archived QA: all 229 summaries replayed exactly, all four Raise Skeletal Mage variants covered, 0 audit findings, and 0 stress failures across 864,600 transformed profiles
- `git diff --check` passed

## Notes

- the repository-wide API suite reaches 318 passing tests but remains blocked by pre-existing `string | string[]` route-parameter TypeScript errors in unchanged `src/routes/characters.ts`
- the usage-driven snapshot contains no Smite sample, so focused API tests cover Smite/Holy Shield behavior
- archived QA documentation is linked from `AGENTS.md`
