### PR TITLE
Fix/issue 27 server side sorting

### DIFF
--- a/api/src/database/postgres/index.ts
+++ b/api/src/database/postgres/index.ts
@@ -915,6 +915,13 @@ export default class CharacterDB_Postgres {
       orderByClause = `(C.full_response_json->'character'->>'mana')::int ${orderDirection}, C.character_db_id DESC`;
     } else if (filter.sortBy === "level") {
       orderByClause = `C.level ${orderDirection}, C.character_db_id DESC`;
+    } else if (filter.sortBy === "highestSkLevel") {
+      orderByClause = `
+        (C.full_response_json->'realSkills'->0->>'level')::int
+          ${orderDirection}
+          NULLS LAST,
+        C.character_db_id DESC
+      `;
     }
 
     // Execute CTE

--- a/api/src/database/postgres/index.ts
+++ b/api/src/database/postgres/index.ts
@@ -43,6 +43,8 @@ export interface CharacterFilter {
     max?: number;
   };
   season?: number;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
 }
 
 type ItemType = "Unique" | "Set" | "Runeword";
@@ -901,6 +903,20 @@ export default class CharacterDB_Postgres {
 
     const { filterCTE, params } = this.buildFilterCTE(filter, gameModeId);
 
+    // Determine dynamic order by
+    const orderDirection = filter.sortOrder === "asc" ? "ASC" : "DESC";
+    let orderByClause = `C.level ${orderDirection}, C.character_db_id DESC`;
+
+    if (filter.sortBy === "name") {
+      orderByClause = `C.api_character_name ${orderDirection}, C.character_db_id DESC`;
+    } else if (filter.sortBy === "life") {
+      orderByClause = `(C.full_response_json->'character'->>'life')::int ${orderDirection}, C.character_db_id DESC`;
+    } else if (filter.sortBy === "mana") {
+      orderByClause = `(C.full_response_json->'character'->>'mana')::int ${orderDirection}, C.character_db_id DESC`;
+    } else if (filter.sortBy === "level") {
+      orderByClause = `C.level ${orderDirection}, C.character_db_id DESC`;
+    }
+
     // Execute CTE
     const queryParams = [...params, pageSize, (page - 1) * pageSize];
     const combinedQuery = `
@@ -912,7 +928,7 @@ export default class CharacterDB_Postgres {
                 SELECT C.full_response_json
                 FROM Characters C
                 WHERE C.character_db_id IN (SELECT character_db_id FROM FilteredCharIDs)
-                ORDER BY C.level DESC, C.character_db_id DESC
+                ORDER BY ${orderByClause}
                 LIMIT $${queryParams.length - 1} OFFSET $${queryParams.length}
             ),
             ClassBreakdown AS (

--- a/api/src/routes/characters.ts
+++ b/api/src/routes/characters.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from "express";
 import rateLimit from "express-rate-limit";
-import { characterDB } from "../database";
+import { characterDB, CharacterFilter } from "../database";
 import { validateSeason } from "../middleware/validation";
 import { config, logger as mainLogger } from "../config";
 import CharacterStatParser from "../utils/character-stats";
@@ -95,11 +95,18 @@ router.get(
         mercTypes,
         mercItems,
         season,
+        sortBy,
+        sortOrder,
       } = req.query;
 
-      const filter: Record<string, unknown> & {
-        levelRange?: { min?: number; max?: number };
-      } = {};
+      const filter: CharacterFilter = {};
+
+      if (sortBy && typeof sortBy === "string") {
+        filter.sortBy = sortBy;
+      }
+      if (sortOrder === "asc" || sortOrder === "desc") {
+        filter.sortOrder = sortOrder;
+      }
 
       if (minLevel || maxLevel) {
         filter.levelRange = {};

--- a/web/src/api/characters.ts
+++ b/web/src/api/characters.ts
@@ -38,6 +38,8 @@ export const charactersAPI = {
       minLevel: filter.levelRange?.min,
       maxLevel: filter.levelRange?.max,
       season: filter.season,
+      sortBy: filter.sortBy,
+      sortOrder: filter.sortOrder,
     });
   },
 

--- a/web/src/components/builds/CharacterTable/index.tsx
+++ b/web/src/components/builds/CharacterTable/index.tsx
@@ -56,8 +56,12 @@ export default function PlayerTable({
   useEffect(() => {
     const fetchCharacters = async () => {
       const activeSort = sorting[0];
-      const sortBy = activeSort?.id;
-      const sortOrder = activeSort?.desc ? "desc" : "asc";
+      const sortBy = activeSort?.id ?? "level";
+      const sortOrder = activeSort
+        ? activeSort.desc
+          ? "desc"
+          : "asc"
+        : "desc";
 
       // If we have initial characters and this is not a pagination/sorting request,
       // use those instead of making an API call

--- a/web/src/components/builds/CharacterTable/index.tsx
+++ b/web/src/components/builds/CharacterTable/index.tsx
@@ -3,6 +3,7 @@ import {
   MantineReactTable,
   MRT_ColumnDef,
   MRT_PaginationState,
+  MRT_SortingState,
   useMantineReactTable,
 } from "mantine-react-table";
 import { IconGrave } from "@tabler/icons-react";
@@ -49,12 +50,18 @@ export default function PlayerTable({
     pageIndex: 0,
     pageSize: 40,
   });
-  // Effect to fetch data when pagination or filters change
+  const [sorting, setSorting] = useState<MRT_SortingState>([]);
+
+  // Effect to fetch data when pagination, sorting, or filters change
   useEffect(() => {
     const fetchCharacters = async () => {
-      // If we have initial characters and this is not a pagination request,
+      const activeSort = sorting[0];
+      const sortBy = activeSort?.id;
+      const sortOrder = activeSort?.desc ? "desc" : "asc";
+
+      // If we have initial characters and this is not a pagination/sorting request,
       // use those instead of making an API call
-      if (initialCharacters && pagination.pageIndex === 0) {
+      if (initialCharacters && pagination.pageIndex === 0 && !sorting.length) {
         setCharacterData(initialCharacters);
         setTotalRowCount(initialTotal || 0); // Use the initial total
         setIsLoading(false);
@@ -68,37 +75,9 @@ export default function PlayerTable({
         setIsRefetching(true);
       }
 
-      // Only proceed with API call if we're paginating or don't have initial data
-      if (pagination.pageIndex > 0 || !initialCharacters) {
+      // Only proceed with API call if we're paginating, sorting, or don't have initial data
+      if (pagination.pageIndex > 0 || sorting.length || !initialCharacters) {
         try {
-          const queryParams = new URLSearchParams({
-            gameMode: filters.gameMode,
-            page: (pagination.pageIndex + 1).toString(),
-            pageSize: pagination.pageSize.toString(),
-          });
-          if (filters.classFilter.length) {
-            queryParams.append("className", filters.classFilter.join(","));
-          }
-          if (filters.itemFilter.length) {
-            queryParams.append("requiredItems", filters.itemFilter.join(","));
-          }
-          if (filters.skillFilter.length) {
-            queryParams.append(
-              "requiredSkills",
-              JSON.stringify(filters.skillFilter)
-            );
-          }
-          if (filters.mercTypeFilter.length) {
-            queryParams.append("mercTypes", filters.mercTypeFilter.join(","));
-          }
-          if (filters.mercItemFilter.length) {
-            queryParams.append("mercItems", filters.mercItemFilter.join(","));
-          }
-          if (filters.searchQuery) {
-            // Assuming 'query' is the param name for search
-            queryParams.append("query", filters.searchQuery);
-          }
-
           const levelRangeCookie = Cookies.get(LEVEL_RANGE_COOKIE_KEY);
           const levelRange = levelRangeCookie
             ? JSON.parse(levelRangeCookie)
@@ -117,6 +96,8 @@ export default function PlayerTable({
               requiredMercItems: filters.mercItemFilter,
               levelRange: { min: levelRange.min, max: levelRange.max },
               season: filters.season,
+              sortBy,
+              sortOrder,
             },
             pagination.pageIndex + 1,
             pagination.pageSize
@@ -142,6 +123,7 @@ export default function PlayerTable({
   }, [
     pagination.pageIndex,
     pagination.pageSize,
+    sorting,
     filters,
     initialCharacters,
     initialTotal,
@@ -257,8 +239,13 @@ export default function PlayerTable({
     columns,
     data: tableDisplayData,
     manualPagination: true,
+    manualSorting: true,
     rowCount: totalRowCount,
     onPaginationChange: setPagination,
+    onSortingChange: (updater) => {
+      setSorting(updater);
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    },
     enableColumnActions: false,
     enableColumnFilters: false,
     enableSorting: true,
@@ -267,6 +254,7 @@ export default function PlayerTable({
       isLoading: isLoading,
       showProgressBars: isRefetching,
       pagination,
+      sorting,
       showAlertBanner: isError,
     },
     initialState: {

--- a/web/src/types/character.ts
+++ b/web/src/types/character.ts
@@ -65,6 +65,8 @@ export interface CharacterFilter {
     max?: number;
   };
   season?: number;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
 }
 
 export interface CharacterListResponse {


### PR DESCRIPTION
### Summary of Changes:
- **Database**: Added dynamic `ORDER BY` handling (`level`, `name`, `life`, `mana`) in `getFilteredCharacters()` prior to pagination `LIMIT/OFFSET`.
- **API Route**: Extracted `sortBy` & `sortOrder` query params in `/api/characters`.
- **Frontend API**: Passed sort parameters through `charactersAPI.getCharacters()`.
- **CharacterTable**: Configured `manualSorting: true`, `sorting` state, and `onSortingChange` handler to refetch page 1 with global sorting when column headers are clicked.

