### PR TITLE
Fix/issue 22 berserker label

### DIFF
--- a/web/src/components/builds/CharacterTable/index.tsx
+++ b/web/src/components/builds/CharacterTable/index.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from "@mantine/core";
 import Cookies from "js-cookie";
 import { charactersAPI } from "../../../api";
 import { DEFAULT_VIEW_SEASON, LEVEL_RANGE_COOKIE_KEY } from "../../../types";
+import { normalizeSkillName } from "../../../utils/equipment-map";
 import type { FullCharacterResponse } from "../../../types";
 import type { CharacterFilters } from "../../../hooks";
 
@@ -229,22 +230,25 @@ export default function PlayerTable({
           return (
             <div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
               {row.original.highestSkLevel || "N/A"}
-              {topSkills.map((sk) => (
-                <Tooltip
-                  key={sk.skill}
-                  label={`${sk.skill} (Level ${sk.level})`}
-                >
-                  <img
-                    src={`/icons/${sk.skill.replaceAll(" ", "_")}.png`}
-                    alt={sk.skill}
-                    style={{
-                      width: "30px",
-                      height: "30px",
-                      marginLeft: "1.5px",
-                    }}
-                  />
-                </Tooltip>
-              ))}
+              {topSkills.map((sk) => {
+                const displayName = normalizeSkillName(sk.skill);
+                return (
+                  <Tooltip
+                    key={sk.skill}
+                    label={`${displayName} (Level ${sk.level})`}
+                  >
+                    <img
+                      src={`/icons/${displayName.replaceAll(" ", "_")}.png`}
+                      alt={displayName}
+                      style={{
+                        width: "30px",
+                        height: "30px",
+                        marginLeft: "1.5px",
+                      }}
+                    />
+                  </Tooltip>
+                );
+              })}
             </div>
           );
         },

--- a/web/src/components/builds/SkillCard/index.tsx
+++ b/web/src/components/builds/SkillCard/index.tsx
@@ -4,6 +4,7 @@ import { IconInfoCircle, IconX } from "@tabler/icons-react";
 import { List, RowComponentProps } from "react-window";
 import type { CharacterFilters, SkillRequirement } from "../../../../hooks";
 import type { SkillUsageStats } from "../../../../types";
+import { normalizeSkillName } from "../../../utils/equipment-map";
 import styles from "../VirtualList.module.css";
 
 interface Props {
@@ -41,18 +42,19 @@ export default function SkillCard({ data, filters, updateFilters }: Props) {
     return data.skillUsage
       .reduce(
         (acc, skill) => {
+          const displayName = normalizeSkillName(skill.name);
           // Early return if it doesn't match search
           if (
             searchQuery &&
-            !skill.name.toLowerCase().startsWith(searchQuery)
+            !displayName.toLowerCase().startsWith(searchQuery)
           ) {
             return acc;
           }
 
           acc.push({
-            name: skill.name,
+            name: displayName,
             percentage: skill.pct,
-            isSelected: selectedSkillsSet.has(skill.name),
+            isSelected: selectedSkillsSet.has(skill.name) || selectedSkillsSet.has(displayName),
           });
           return acc;
         },

--- a/web/src/components/builds/SkillCard/index.tsx
+++ b/web/src/components/builds/SkillCard/index.tsx
@@ -52,13 +52,14 @@ export default function SkillCard({ data, filters, updateFilters }: Props) {
           }
 
           acc.push({
-            name: displayName,
+            rawName: skill.name,
+            displayName,
             percentage: skill.pct,
-            isSelected: selectedSkillsSet.has(skill.name) || selectedSkillsSet.has(displayName),
+            isSelected: selectedSkillsSet.has(skill.name),
           });
           return acc;
         },
-        [] as Array<{ name: string; percentage: number; isSelected: boolean }>
+        [] as Array<{ rawName: string; displayName: string; percentage: number; isSelected: boolean }>
       )
       .sort(
         (a, b) =>
@@ -74,18 +75,18 @@ export default function SkillCard({ data, filters, updateFilters }: Props) {
   const listHeight = Math.min(skillPercentages.length * ROW_HEIGHT, MAX_HEIGHT);
   const needsScroll = skillPercentages.length * ROW_HEIGHT > MAX_HEIGHT;
 
-  type SkillRowData = { name: string; percentage: number; isSelected: boolean };
+  type SkillRowData = { rawName: string; displayName: string; percentage: number; isSelected: boolean };
 
   const SkillRow = ({
     index,
     skills,
     style,
   }: RowComponentProps<{ skills: SkillRowData[] }>) => {
-    const { name, percentage, isSelected } = skills[index];
+    const { rawName, displayName, percentage, isSelected } = skills[index];
     return (
       <div style={style}>
         <Paper
-          key={name}
+          key={rawName}
           withBorder
           radius={0}
           p="5"
@@ -106,7 +107,7 @@ export default function SkillCard({ data, filters, updateFilters }: Props) {
             if (backgroundBar) {
               backgroundBar.style.width = "0%";
             }
-            handleSkillSelect(name);
+            handleSkillSelect(rawName);
           }}
         >
           <div
@@ -122,7 +123,7 @@ export default function SkillCard({ data, filters, updateFilters }: Props) {
               zIndex: 0,
             }}
           />
-          <Tooltip label={name} position="right" openDelay={250} withArrow>
+          <Tooltip label={displayName} position="right" openDelay={250} withArrow>
             <Flex
               justify="space-between"
               align="center"
@@ -130,8 +131,8 @@ export default function SkillCard({ data, filters, updateFilters }: Props) {
             >
               <Flex align="center" gap="6px" style={{ minWidth: 0 }}>
                 <img
-                  src={`/icons/${name.replaceAll(" ", "_")}.png`}
-                  alt={name}
+                  src={`/icons/${displayName.replaceAll(" ", "_")}.png`}
+                  alt={displayName}
                   style={{
                     width: "20px",
                     height: "20px",
@@ -139,7 +140,7 @@ export default function SkillCard({ data, filters, updateFilters }: Props) {
                     objectFit: "contain",
                   }}
                 />
-                <Text lineClamp={1}>{name}</Text>
+                <Text lineClamp={1}>{displayName}</Text>
               </Flex>
               {isSelected ? (
                 <ActionIcon
@@ -147,7 +148,7 @@ export default function SkillCard({ data, filters, updateFilters }: Props) {
                   variant="default"
                   onClick={(e) => {
                     e.stopPropagation();
-                    handleSkillSelect(name);
+                    handleSkillSelect(rawName);
                   }}
                 >
                   <IconX size={14} />

--- a/web/src/utils/equipment-map.ts
+++ b/web/src/utils/equipment-map.ts
@@ -259,4 +259,9 @@ const skillCategories = new Map([
   ["Cold Mastery", "Cold Spells"],
 ]);
 
+export function normalizeSkillName(name: string): string {
+  if (name === "Berserker") return "Berserk";
+  return name;
+}
+
 export default skillCategories;


### PR DESCRIPTION
### Summary of Changes:
- Added `normalizeSkillName()` helper in `web/src/utils/equipment-map.ts` to map `"Berserker"` -> `"Berserk"`.
- Applied normalization in `SkillCard` and `CharacterTable` so display names, search filters, and tooltips match the canonical PD2 skill name on the frontend without requiring database re-ingestion.
