### PR TITLE
fix(web): add Fend to Amazon Javelin and Spear Skills category (#28)

### DIFF
--- a/web/src/components/character/map.ts
+++ b/web/src/components/character/map.ts
@@ -16,6 +16,7 @@ const skillCategories = new Map([
   ["Power Strike", "Javelin and Spear Skills"],
   ["Poison Javelin", "Javelin and Spear Skills"],
   ["Impale", "Javelin and Spear Skills"],
+  ["Fend", "Javelin and Spear Skills"],
   ["Lightning Strike", "Javelin and Spear Skills"],
   ["Charged Strike", "Javelin and Spear Skills"],
   ["Plague Javelin", "Javelin and Spear Skills"],

--- a/web/src/utils/equipment-map.ts
+++ b/web/src/utils/equipment-map.ts
@@ -16,6 +16,7 @@ const skillCategories = new Map([
   ["Power Strike", "Javelin and Spear Skills"],
   ["Poison Javelin", "Javelin and Spear Skills"],
   ["Impale", "Javelin and Spear Skills"],
+  ["Fend", "Javelin and Spear Skills"],
   ["Lightning Strike", "Javelin and Spear Skills"],
   ["Charged Strike", "Javelin and Spear Skills"],
   ["Plague Javelin", "Javelin and Spear Skills"],


### PR DESCRIPTION
### Summary of Changes:
- Added `["Fend", "Javelin and Spear Skills"]` to `skillCategories` in `web/src/utils/equipment-map.ts` and `web/src/components/character/map.ts`.