### PR TITLE
Feature/issue 18 filter rare magic crafted items on builds page

### DIFF
--- a/api/src/database/postgres/index.ts
+++ b/api/src/database/postgres/index.ts
@@ -47,7 +47,7 @@ export interface CharacterFilter {
   sortOrder?: "asc" | "desc";
 }
 
-type ItemType = "Unique" | "Set" | "Runeword";
+type ItemType = "Unique" | "Set" | "Runeword" | "Rare" | "Magic" | "Crafted";
 
 export interface ItemUsageStats {
   item: string;
@@ -1106,6 +1106,9 @@ export default class CharacterDB_Postgres {
                     WHEN CI.is_runeword = true AND BI.name <> ALL($${params.length + 1}) THEN 'Runeword'
                     WHEN Q.name = 'Unique' AND BI.name <> ALL($${params.length + 2}) THEN 'Unique'
                     WHEN Q.name = 'Set' THEN 'Set'
+                    WHEN Q.name = 'Crafted' THEN 'Crafted'
+                    WHEN Q.name = 'Rare' THEN 'Rare'
+                    WHEN Q.name = 'Magic' THEN 'Magic'
                     ELSE NULL
                 END AS itemType,
                 COUNT(DISTINCT CI.character_db_id) AS numOccurrences,
@@ -1118,6 +1121,9 @@ export default class CharacterDB_Postgres {
                 WHEN CI.is_runeword = true AND BI.name <> ALL($${params.length + 1}) THEN 'Runeword'
                 WHEN Q.name = 'Unique' AND BI.name <> ALL($${params.length + 2}) THEN 'Unique'
                 WHEN Q.name = 'Set' THEN 'Set'
+                WHEN Q.name = 'Crafted' THEN 'Crafted'
+                WHEN Q.name = 'Rare' THEN 'Rare'
+                WHEN Q.name = 'Magic' THEN 'Magic'
                 ELSE NULL
             END IS NOT NULL
             GROUP BY BI.name, itemType
@@ -1243,6 +1249,9 @@ export default class CharacterDB_Postgres {
                     WHEN MI.is_runeword = true THEN 'Runeword'
                     WHEN Q.name = 'Unique' THEN 'Unique'
                     WHEN Q.name = 'Set' THEN 'Set'
+                    WHEN Q.name = 'Crafted' THEN 'Crafted'
+                    WHEN Q.name = 'Rare' THEN 'Rare'
+                    WHEN Q.name = 'Magic' THEN 'Magic'
                     ELSE NULL
                 END AS itemType,
                 COUNT(DISTINCT MI.character_db_id) AS numOccurrences,
@@ -1255,6 +1264,9 @@ export default class CharacterDB_Postgres {
                 WHEN MI.is_runeword = true THEN 'Runeword'
                 WHEN Q.name = 'Unique' THEN 'Unique'
                 WHEN Q.name = 'Set' THEN 'Set'
+                WHEN Q.name = 'Crafted' THEN 'Crafted'
+                WHEN Q.name = 'Rare' THEN 'Rare'
+                WHEN Q.name = 'Magic' THEN 'Magic'
                 ELSE NULL
             END IS NOT NULL
             GROUP BY BI.name, itemType

--- a/api/src/database/postgres/index.ts
+++ b/api/src/database/postgres/index.ts
@@ -76,6 +76,9 @@ const IGNORED_UNIQUES_ARRAY = [
   "Annihilus",
   "Call to Arms",
   "Lidless Wall",
+  "Small Charm",
+  "Large Charm",
+  "Grand Charm",
 ];
 
 export default class CharacterDB_Postgres {
@@ -1106,9 +1109,9 @@ export default class CharacterDB_Postgres {
                     WHEN CI.is_runeword = true AND BI.name <> ALL($${params.length + 1}) THEN 'Runeword'
                     WHEN Q.name = 'Unique' AND BI.name <> ALL($${params.length + 2}) THEN 'Unique'
                     WHEN Q.name = 'Set' THEN 'Set'
-                    WHEN Q.name = 'Crafted' THEN 'Crafted'
-                    WHEN Q.name = 'Rare' THEN 'Rare'
-                    WHEN Q.name = 'Magic' THEN 'Magic'
+                    WHEN Q.name = 'Crafted' AND BI.name NOT LIKE '%Charm' THEN 'Crafted'
+                    WHEN Q.name = 'Rare' AND BI.name NOT LIKE '%Charm' THEN 'Rare'
+                    WHEN Q.name = 'Magic' AND BI.name NOT LIKE '%Charm' THEN 'Magic'
                     ELSE NULL
                 END AS itemType,
                 COUNT(DISTINCT CI.character_db_id) AS numOccurrences,
@@ -1121,9 +1124,9 @@ export default class CharacterDB_Postgres {
                 WHEN CI.is_runeword = true AND BI.name <> ALL($${params.length + 1}) THEN 'Runeword'
                 WHEN Q.name = 'Unique' AND BI.name <> ALL($${params.length + 2}) THEN 'Unique'
                 WHEN Q.name = 'Set' THEN 'Set'
-                WHEN Q.name = 'Crafted' THEN 'Crafted'
-                WHEN Q.name = 'Rare' THEN 'Rare'
-                WHEN Q.name = 'Magic' THEN 'Magic'
+                WHEN Q.name = 'Crafted' AND BI.name NOT LIKE '%Charm' THEN 'Crafted'
+                WHEN Q.name = 'Rare' AND BI.name NOT LIKE '%Charm' THEN 'Rare'
+                WHEN Q.name = 'Magic' AND BI.name NOT LIKE '%Charm' THEN 'Magic'
                 ELSE NULL
             END IS NOT NULL
             GROUP BY BI.name, itemType

--- a/api/src/database/postgres/index.ts
+++ b/api/src/database/postgres/index.ts
@@ -915,6 +915,13 @@ export default class CharacterDB_Postgres {
       orderByClause = `(C.full_response_json->'character'->>'mana')::int ${orderDirection}, C.character_db_id DESC`;
     } else if (filter.sortBy === "level") {
       orderByClause = `C.level ${orderDirection}, C.character_db_id DESC`;
+    } else if (filter.sortBy === "highestSkLevel") {
+      orderByClause = `
+        (C.full_response_json->'realSkills'->0->>'level')::int
+          ${orderDirection}
+          NULLS LAST,
+        C.character_db_id DESC
+      `;
     }
 
     // Execute CTE

--- a/api/src/database/postgres/index.ts
+++ b/api/src/database/postgres/index.ts
@@ -43,6 +43,8 @@ export interface CharacterFilter {
     max?: number;
   };
   season?: number;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
 }
 
 type ItemType = "Unique" | "Set" | "Runeword";
@@ -901,6 +903,20 @@ export default class CharacterDB_Postgres {
 
     const { filterCTE, params } = this.buildFilterCTE(filter, gameModeId);
 
+    // Determine dynamic order by
+    const orderDirection = filter.sortOrder === "asc" ? "ASC" : "DESC";
+    let orderByClause = `C.level ${orderDirection}, C.character_db_id DESC`;
+
+    if (filter.sortBy === "name") {
+      orderByClause = `C.api_character_name ${orderDirection}, C.character_db_id DESC`;
+    } else if (filter.sortBy === "life") {
+      orderByClause = `(C.full_response_json->'character'->>'life')::int ${orderDirection}, C.character_db_id DESC`;
+    } else if (filter.sortBy === "mana") {
+      orderByClause = `(C.full_response_json->'character'->>'mana')::int ${orderDirection}, C.character_db_id DESC`;
+    } else if (filter.sortBy === "level") {
+      orderByClause = `C.level ${orderDirection}, C.character_db_id DESC`;
+    }
+
     // Execute CTE
     const queryParams = [...params, pageSize, (page - 1) * pageSize];
     const combinedQuery = `
@@ -912,7 +928,7 @@ export default class CharacterDB_Postgres {
                 SELECT C.full_response_json
                 FROM Characters C
                 WHERE C.character_db_id IN (SELECT character_db_id FROM FilteredCharIDs)
-                ORDER BY C.level DESC, C.character_db_id DESC
+                ORDER BY ${orderByClause}
                 LIMIT $${queryParams.length - 1} OFFSET $${queryParams.length}
             ),
             ClassBreakdown AS (

--- a/api/src/routes/characters.ts
+++ b/api/src/routes/characters.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from "express";
 import rateLimit from "express-rate-limit";
-import { characterDB } from "../database";
+import { characterDB, CharacterFilter } from "../database";
 import { validateSeason } from "../middleware/validation";
 import { config, logger as mainLogger } from "../config";
 import CharacterStatParser from "../utils/character-stats";
@@ -95,11 +95,18 @@ router.get(
         mercTypes,
         mercItems,
         season,
+        sortBy,
+        sortOrder,
       } = req.query;
 
-      const filter: Record<string, unknown> & {
-        levelRange?: { min?: number; max?: number };
-      } = {};
+      const filter: CharacterFilter = {};
+
+      if (sortBy && typeof sortBy === "string") {
+        filter.sortBy = sortBy;
+      }
+      if (sortOrder === "asc" || sortOrder === "desc") {
+        filter.sortOrder = sortOrder;
+      }
 
       if (minLevel || maxLevel) {
         filter.levelRange = {};

--- a/web/src/api/characters.ts
+++ b/web/src/api/characters.ts
@@ -38,6 +38,8 @@ export const charactersAPI = {
       minLevel: filter.levelRange?.min,
       maxLevel: filter.levelRange?.max,
       season: filter.season,
+      sortBy: filter.sortBy,
+      sortOrder: filter.sortOrder,
     });
   },
 

--- a/web/src/components/builds/CharacterTable/index.tsx
+++ b/web/src/components/builds/CharacterTable/index.tsx
@@ -56,8 +56,12 @@ export default function PlayerTable({
   useEffect(() => {
     const fetchCharacters = async () => {
       const activeSort = sorting[0];
-      const sortBy = activeSort?.id;
-      const sortOrder = activeSort?.desc ? "desc" : "asc";
+      const sortBy = activeSort?.id ?? "level";
+      const sortOrder = activeSort
+        ? activeSort.desc
+          ? "desc"
+          : "asc"
+        : "desc";
 
       // If we have initial characters and this is not a pagination/sorting request,
       // use those instead of making an API call

--- a/web/src/components/builds/CharacterTable/index.tsx
+++ b/web/src/components/builds/CharacterTable/index.tsx
@@ -3,6 +3,7 @@ import {
   MantineReactTable,
   MRT_ColumnDef,
   MRT_PaginationState,
+  MRT_SortingState,
   useMantineReactTable,
 } from "mantine-react-table";
 import { IconGrave } from "@tabler/icons-react";
@@ -49,12 +50,18 @@ export default function PlayerTable({
     pageIndex: 0,
     pageSize: 40,
   });
-  // Effect to fetch data when pagination or filters change
+  const [sorting, setSorting] = useState<MRT_SortingState>([]);
+
+  // Effect to fetch data when pagination, sorting, or filters change
   useEffect(() => {
     const fetchCharacters = async () => {
-      // If we have initial characters and this is not a pagination request,
+      const activeSort = sorting[0];
+      const sortBy = activeSort?.id;
+      const sortOrder = activeSort?.desc ? "desc" : "asc";
+
+      // If we have initial characters and this is not a pagination/sorting request,
       // use those instead of making an API call
-      if (initialCharacters && pagination.pageIndex === 0) {
+      if (initialCharacters && pagination.pageIndex === 0 && !sorting.length) {
         setCharacterData(initialCharacters);
         setTotalRowCount(initialTotal || 0); // Use the initial total
         setIsLoading(false);
@@ -68,37 +75,9 @@ export default function PlayerTable({
         setIsRefetching(true);
       }
 
-      // Only proceed with API call if we're paginating or don't have initial data
-      if (pagination.pageIndex > 0 || !initialCharacters) {
+      // Only proceed with API call if we're paginating, sorting, or don't have initial data
+      if (pagination.pageIndex > 0 || sorting.length || !initialCharacters) {
         try {
-          const queryParams = new URLSearchParams({
-            gameMode: filters.gameMode,
-            page: (pagination.pageIndex + 1).toString(),
-            pageSize: pagination.pageSize.toString(),
-          });
-          if (filters.classFilter.length) {
-            queryParams.append("className", filters.classFilter.join(","));
-          }
-          if (filters.itemFilter.length) {
-            queryParams.append("requiredItems", filters.itemFilter.join(","));
-          }
-          if (filters.skillFilter.length) {
-            queryParams.append(
-              "requiredSkills",
-              JSON.stringify(filters.skillFilter)
-            );
-          }
-          if (filters.mercTypeFilter.length) {
-            queryParams.append("mercTypes", filters.mercTypeFilter.join(","));
-          }
-          if (filters.mercItemFilter.length) {
-            queryParams.append("mercItems", filters.mercItemFilter.join(","));
-          }
-          if (filters.searchQuery) {
-            // Assuming 'query' is the param name for search
-            queryParams.append("query", filters.searchQuery);
-          }
-
           const levelRangeCookie = Cookies.get(LEVEL_RANGE_COOKIE_KEY);
           const levelRange = levelRangeCookie
             ? JSON.parse(levelRangeCookie)
@@ -117,6 +96,8 @@ export default function PlayerTable({
               requiredMercItems: filters.mercItemFilter,
               levelRange: { min: levelRange.min, max: levelRange.max },
               season: filters.season,
+              sortBy,
+              sortOrder,
             },
             pagination.pageIndex + 1,
             pagination.pageSize
@@ -142,6 +123,7 @@ export default function PlayerTable({
   }, [
     pagination.pageIndex,
     pagination.pageSize,
+    sorting,
     filters,
     initialCharacters,
     initialTotal,
@@ -257,8 +239,13 @@ export default function PlayerTable({
     columns,
     data: tableDisplayData,
     manualPagination: true,
+    manualSorting: true,
     rowCount: totalRowCount,
     onPaginationChange: setPagination,
+    onSortingChange: (updater) => {
+      setSorting(updater);
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    },
     enableColumnActions: false,
     enableColumnFilters: false,
     enableSorting: true,
@@ -267,6 +254,7 @@ export default function PlayerTable({
       isLoading: isLoading,
       showProgressBars: isRefetching,
       pagination,
+      sorting,
       showAlertBanner: isError,
     },
     initialState: {

--- a/web/src/components/builds/UniqueCard/index.tsx
+++ b/web/src/components/builds/UniqueCard/index.tsx
@@ -93,7 +93,13 @@ export default function UniqueCard({ data, filters, updateFilters }: Props) {
       case "Set":
         return "rgba(30, 237, 14, 0.35)";
       case "Runeword":
-        return "rgba(250, 204, 21, 0.35)";
+        return "rgba(156, 163, 175, 0.35)";
+      case "Rare":
+        return "rgba(255, 255, 0, 0.35)";
+      case "Magic":
+        return "rgba(69, 69, 255, 0.35)";
+      case "Crafted":
+        return "rgba(255, 168, 0, 0.35)";
       default:
         return "rgba(200, 200, 200, 0.1)";
     }

--- a/web/src/components/builds/shared/item-colors.ts
+++ b/web/src/components/builds/shared/item-colors.ts
@@ -5,7 +5,13 @@ export const getItemTypeBaseColor = (type: string): string => {
     case "Set":
       return "#1eed0e";
     case "Runeword":
-      return "#FACC15";
+      return "#9CA3AF";
+    case "Rare":
+      return "#ffff00";
+    case "Magic":
+      return "#4545ff";
+    case "Crafted":
+      return "#ffa800";
     default:
       return "#6b7280";
   }

--- a/web/src/types/character.ts
+++ b/web/src/types/character.ts
@@ -77,7 +77,7 @@ export interface CharacterListResponse {
 
 export interface ItemUsageStats {
   item: string;
-  itemType: "Unique" | "Set" | "Runeword";
+  itemType: "Unique" | "Set" | "Runeword" | "Rare" | "Magic" | "Crafted";
   numOccurrences: number;
   totalSample: number;
   pct: number;

--- a/web/src/types/character.ts
+++ b/web/src/types/character.ts
@@ -65,6 +65,8 @@ export interface CharacterFilter {
     max?: number;
   };
   season?: number;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
 }
 
 export interface CharacterListResponse {


### PR DESCRIPTION
### Summary of Changes
Extends item usage statistics and filtering on `/builds` beyond Uniques, Sets, and Runewords to also include **Rare**, **Magic**, and **Crafted** items.

1. **Backend (`api`):** 
   - Extended `analyzeItemUsage` and `analyzeMercItemUsage` queries in `postgres/index.ts` to categorize `Rare`, `Magic`, and `Crafted` item qualities.
   - Evaluates item quality in proper hierarchy order (`Runeword -> Unique -> Set -> Crafted -> Rare -> Magic`).

2. **Frontend (`web`):**
   - Added rarity badge styles matching site standard colors for Rare (Yellow `#ffff00`), Magic (Blue `#4545ff`), and Crafted (Orange `#ffa800`).
   - SUGGESTION (but added): Runewords could use a **greyish background color (`#9CA3AF`)** to visually separate them from gold/yellow rare items.

### Tradeoffs & Feedback
- Extending filtering beyond just Rare items to also include Magic and Crafted items makes the `/builds` page filter much more powerful and complete for PD2 build discovery.
- *Note on UI density:* Including all item qualities increases the number of entries in the left-side Items selection panel (`UniqueCard`). While the virtualized list handles this smoothly, maintainers might want to observe if secondary base items create clutter on the UI.
